### PR TITLE
use `proj_context_destroy` instead of `proj_destroy`

### DIFF
--- a/src/epsg2epsg.jl
+++ b/src/epsg2epsg.jl
@@ -26,7 +26,7 @@ function epsg2epsg(source_epsg::EPSG, target_epsg::EPSG; threaded=true, proj_onl
                 end
                 return xx, yy
             end
-            foreach(Proj.proj_destroy, ctxs)
+            foreach(Proj.proj_context_destroy, ctxs)
             return f
         else
             f = function (x::Union{Real,Vector{<:Real}}, y::Union{Real,Vector{<:Real}})


### PR DESCRIPTION
This was working fine when I wrote it, but somehow on a new Mac it threw a SIGUSR and shut down the process.

Turns out that this is the correct destructor, not proj_destroy.