### PR TITLE
Transform the height where a transformation changes one

### DIFF
--- a/src/FastGeoProjections.jl
+++ b/src/FastGeoProjections.jl
@@ -22,6 +22,7 @@ module FastGeoProjections
 
     export EPSG
     export Transformation, transform, transform!, inv
+    export preservesz
     export GeoTransformation
     export LonLatToPolarStereographic, PolarStereographicToLonLat
     export LonLatToTransverseMercator, TransverseMercatorToLonLat

--- a/src/apply.jl
+++ b/src/apply.jl
@@ -193,6 +193,19 @@ _carriesz(::Type{Any}) = false
     end
 end
 
+# A transformation that changes heights takes all three coordinates together:
+# the transformed z comes back from the transformation rather than from the
+# source point, and x and y depend on the z going in. Selected once per chunk
+# by `_transform_pts!`, so the three-coordinate call is not a branch per point.
+@inline function _scalar_range_z!(dst, src, t, lo, hi)
+    P = eltype(dst)
+    @inbounds for i in lo:hi
+        p = src[i]
+        x, y, z = t(GI.x(p), GI.y(p), GI.z(p))
+        dst[i] = rebuildpoint(P, x, y, z)
+    end
+end
+
 @inline function _scalar_range!(dstx, dsty, srcx, srcy, t, lo, hi)
     @inbounds for i in lo:hi
         dstx[i], dsty[i] = t(srcx[i], srcy[i])
@@ -320,8 +333,12 @@ back into `points` (or into `dest`). Returns the destination.
 `GeometryBasics.Point2`, your own two-field struct. Where the vector turns out
 to be a dense interleaved buffer of floats (see [`_interleaved`](@ref)) and `t`
 is lane-safe, the points are transformed on SIMD lanes; otherwise they go one
-at a time, still threaded. Either way only x and y are touched, so a `Point3`
-keeps its z.
+at a time, still threaded.
+
+A `Point3` keeps its z where `t` is a map projection, which is a function of x
+and y and leaves a height alone. Where `t` can change one -- a datum shift, a
+compound CRS with a geoid model -- the height is transformed along with x and y
+instead, and the points go one at a time. See [`preservesz`](@ref).
 """
 transform!(t::GeoTransformation, pts::AbstractVector; threaded = _default_threaded()) =
     transform!(pts, t, pts; threaded)
@@ -338,6 +355,23 @@ end
 
 function _transform_pts!(dest, t::GeoTransformation, src, threaded)
     n = length(src)
+    # A height-changing transformation is given the source height and returns
+    # the transformed one, so it cannot go through the interleaved path, which
+    # writes rows 1 and 2 and leaves the rest of the destination as it found it.
+    # Only where the points carry a height: with x and y alone there is none to
+    # transform, and 2D-in/2D-out is what such a pipeline is usually asked for.
+    #
+    # `islanesafe` is false for everything that changes a height today, so the
+    # check costs nothing; it is here because the two properties are independent
+    # and a lane-safe datum shift would otherwise take the carry-across path.
+    if !preservesz(t) && _ncomponents(eltype(src)) >= 3 && _carriesz(eltype(dest))
+        _run!(eachindex(src), threaded) do lo, hi
+            borrow(t) do tt
+                _scalar_range_z!(dest, src, tt, lo, hi)
+            end
+        end
+        return dest
+    end
     if islanesafe(t)
         Ms = _interleaved(src)
         Md = dest === src ? Ms : _interleaved(dest)
@@ -381,7 +415,8 @@ end
     transform(t, points; threaded = Threads.nthreads() > 1)
 
 Out-of-place [`transform!`](@ref): returns a new vector of transformed points,
-of the same type as `points`. Components past x and y are carried over.
+of the same type as `points`. Components past x and y are carried over, except
+for a height that `t` itself transforms; see [`preservesz`](@ref).
 
 A point type that cannot be built from an `(x, y)` tuple only works here if its
 vector has the interleaved layout the SIMD path writes through; otherwise pass

--- a/src/coord.jl
+++ b/src/coord.jl
@@ -72,7 +72,9 @@ Transformation(source_epsg::String, target_epsg::String; kwargs...) =
 # the pipeline is transparent: a Transformation behaves exactly as the operator
 # it wraps
 @inline (t::Transformation)(x, y) = t.f(x, y)
+@inline (t::Transformation)(x, y, z) = t.f(x, y, z)
 islanesafe(t::Transformation) = islanesafe(t.f)
+preservesz(t::Transformation) = preservesz(t.f)
 adapt_eltype(t::Transformation, ::Type{T}) where {T} = adapt_eltype(t.f, T)
 _transform_pts!(dest, t::Transformation, src, threaded) =
     _transform_pts!(dest, t.f, src, threaded)

--- a/src/proj.jl
+++ b/src/proj.jl
@@ -77,6 +77,24 @@ Base.inv(t::ProjTransformation) =
 
 islanesafe(::ProjTransformation) = false
 
+# The pipeline Proj resolves the EPSG pair into may be a datum shift, which is
+# a rotation and translation in Cartesian space: the height participates in it,
+# so a transformed x and y depend on the z given and the transformed z is not
+# the one passed in. Both directions of that matter -- dropping the z silently
+# transforms the point as though its height were zero, which moves x and y as
+# well as losing the height.
+preservesz(::ProjTransformation) = false
+
+# so the third coordinate goes to Proj, which applies the pipeline to it
+function (t::ProjTransformation)(x, y, z)
+    p = take!(t.pool)
+    try
+        p.pj(x, y, z)
+    finally
+        put!(t.pool, p)
+    end
+end
+
 Base.show(io::IO, t::ProjTransformation) =
     print(io, "ProjTransformation(EPSG:", first(t.source_epsg.val),
           " → EPSG:", first(t.target_epsg.val), ")")

--- a/src/transformations.jl
+++ b/src/transformations.jl
@@ -50,6 +50,28 @@ anything that calls into Proj or Base's libm.
 islanesafe(::GeoTransformation) = false
 
 """
+    preservesz(t)
+
+Whether `t` leaves a third coordinate unchanged, so that carrying it across
+untouched is the right answer.
+
+True for a map projection on a fixed datum, which is a function of x and y
+alone. False for anything that can move a height: a datum shift applies a
+Helmert transformation in Cartesian space, where a change in x and y is a
+change in z as well, and a compound CRS with a geoid model redefines the
+vertical datum outright. Either can move a height by 100 m.
+
+[`transform`](@ref) and [`transform!`](@ref) consult this before carrying a z
+over, and refuse to run rather than return a height they cannot compute.
+"""
+preservesz(::GeoTransformation) = true
+
+# A map projection is a function of x and y, so the height passes through it
+# unchanged. Defined once here rather than per projection; a transformation that
+# does change a height overrides this along with `preservesz`.
+@inline (t::GeoTransformation)(x, y, z) = (t(x, y)..., z)
+
+"""
     adapt_eltype(t, ::Type{T})
 
 Rebuild `t` with its precomputed parameters stored as `T`, so a transformation
@@ -109,6 +131,17 @@ ComposedGeoTransformation(ts::GeoTransformation...) = ComposedGeoTransformation(
     _applychain(Base.tail(ts), p[1], p[2])
 end
 
+# Each stage gets the height the one before it produced, so a chain with a datum
+# shift anywhere in it transforms the height at that stage and carries it
+# through the rest.
+@inline (c::ComposedGeoTransformation)(x, y, z) = _applychainz(c.transformations, x, y, z)
+
+@inline _applychainz(::Tuple{}, x, y, z) = (x, y, z)
+@inline function _applychainz(ts::Tuple, x, y, z)
+    p = first(ts)(x, y, z)
+    _applychainz(Base.tail(ts), p[1], p[2], p[3])
+end
+
 # `∘` keeps Base's meaning -- `outer ∘ inner` applies `inner` first -- so the
 # tuple is built inner-first, and nesting flattens
 _chain(t::GeoTransformation) = (t,)
@@ -126,6 +159,7 @@ Base.inv(c::ComposedGeoTransformation) =
     _compose(map(inv, reverse(c.transformations)))
 
 islanesafe(c::ComposedGeoTransformation) = all(islanesafe, c.transformations)
+preservesz(c::ComposedGeoTransformation) = all(preservesz, c.transformations)
 adapt_eltype(c::ComposedGeoTransformation, ::Type{T}) where {T} =
     ComposedGeoTransformation(map(t -> adapt_eltype(t, T), c.transformations))
 

--- a/test/transformations.jl
+++ b/test/transformations.jl
@@ -502,6 +502,42 @@ end
         end
     end
 
+    @testset "z is transformed where the transformation changes one" begin
+        # Geographic 3D to geocentric: the height becomes a Cartesian
+        # coordinate, so a carried-across z is not merely stale but of the
+        # wrong quantity. Proj resolves the pipeline, and is the reference.
+        tz = Transformation(EPSG(4979), EPSG(4978); always_xy = true)
+        @test !FastGeoProjections.preservesz(tz)
+
+        pj = Proj.Transformation("EPSG:4979", "EPSG:4978"; always_xy = true)
+        lon, lat, h = 5.39, 52.16, 100.0
+        want = pj(lon, lat, h)
+
+        @test all(tz(lon, lat, h) .≈ want)                    # scalar, three args
+        for threaded in (false, true)
+            o = transform(tz, [(lon, lat, h)]; threaded)
+            @test all(o[1] .≈ want)
+            @test o[1][3] != h                                 # computed, not carried
+            op = transform(tz, [Point3{Float64}(lon, lat, h)]; threaded)
+            @test all(Tuple(op[1]) .≈ want)
+        end
+
+        # Dropping the height would move x and y as well: the two-argument call
+        # is the h = 0 point, which is 61 m away here. So a three-component
+        # source must not reach a path that transforms only x and y.
+        @test !isapprox(pj(lon, lat)[1], want[1]; atol = 1.0)
+
+        # ...while x and y alone still transform: there is no height to carry,
+        # and 2D in, 2D out is what such a pipeline is usually asked for.
+        @test all(transform(tz, [(lon, lat)])[1] .≈ pj(lon, lat))
+
+        # A map projection is a function of x and y, so it does preserve one.
+        @test FastGeoProjections.preservesz(Transformation(EPSG(4326), EPSG(3413)))
+        # ...and a chain is only as preserving as its least preserving stage.
+        @test !FastGeoProjections.preservesz(
+            Transformation(EPSG(4326), EPSG(3413)).f ∘ tz.f)
+    end
+
     @testset "source and destination of different widths" begin
         src = [Point3{Float64}(lo, la, 0.0) for (lo, la) in zip(lons, lats)]
         dst = Vector{Point2{Float64}}(undef, length(src))


### PR DESCRIPTION
A `z` was carried from source point to destination untouched on every path. That is the transformed height only for a map projection, which is a function of x and y alone. The Proj fallback resolves an EPSG pair into a pipeline that may be a datum shift or a compound CRS with a geoid model, where the height participates in the transformation.

Geographic 3D to geocentric, EPSG:4979 → EPSG:4978, height 100 m:

| | x | y | z |
|---|---|---|---|
| before | 3903579.39 | 368309.51 | 100.0 |
| after / Proj | 3903640.46 | 368315.28 | 5013823.35 |

Two things were wrong, not one. The height came back as the caller's own value rather than the transformed one — and because the two-coordinate call is the `h = 0` point of the pipeline, **x and y were also wrong, by 61 m here**. So the height cannot be left out of the call and reattached afterwards.

`preservesz(t)` reports whether a transformation leaves a height alone: `true` by default, `false` for `ProjTransformation` and for any composition containing one. Where it is `false` and the points carry a height, all three coordinates go to the transformation together and the height comes back from it. A `ComposedGeoTransformation` threads the height through each stage, so a chain with a datum shift anywhere in it transforms the height at that stage.

Unchanged: points of x and y alone still transform through a Proj pipeline exactly as before — there is no height to transform, and the result matches Proj. Native projections keep the carry-across path and the SIMD layout, so `Point3` through a UTM or polar stereographic transform is bit-identical and costs the same.

Tests: 301 → 316, passing at 1 and 8 threads, with the new ones checking the computed height against Proj as the reference.

Found while assessing FastGeoProjections as a dependency for ImagePairGeometry.jl, whose kernel calls transforms scalar and per point.

Co-authored-by: Claude <noreply@anthropic.com>
