### PR TITLE
Add geocentric conversions, fused into the projection after them

### DIFF
--- a/src/FastGeoProjections.jl
+++ b/src/FastGeoProjections.jl
@@ -13,9 +13,12 @@ module FastGeoProjections
     include("ellipsoids.jl")
     include("transformations.jl")
     include("apply.jl")
+    include("projections/direction.jl")
     include("projections/polarstereo.jl")
     include("projections/tranmerc.jl")
     include("projections/utm.jl")
+    include("projections/geocentric.jl")
+    include("projections/fuse.jl")
     include("proj.jl")
     include("epsg.jl")
     include("coord.jl")
@@ -27,5 +30,6 @@ module FastGeoProjections
     export LonLatToPolarStereographic, PolarStereographicToLonLat
     export LonLatToTransverseMercator, TransverseMercatorToLonLat
     export LonLatToUTM, UTMToLonLat, convergence_scale
+    export LonLatToGeocentric, GeocentricToLonLat
     export Math, MathKernel, BaseKernel, SLEEFKernel, FastKernel
 end

--- a/src/ellipsoids.jl
+++ b/src/ellipsoids.jl
@@ -7,7 +7,10 @@ struct Ellipsoid
     a::Float64        # Semi-major axis
     b::Float64        # Semi-minor axis
     f::Float64        # Flattening
-    e::Float64        # Eccentricity 
+    e::Float64        # Eccentricity
+    e2::Float64       # Eccentricity squared, stored rather than derived: the geocentric
+                      # conversions use it directly, and f * (2 - f) keeps a bit that
+                      # squaring `e` back up loses.
     name::Union{Nothing,Symbol}      # Conventional name - for clarity, should match the name
     epsg::EPSG         # epsg code
     # of the const instance in the package!
@@ -34,8 +37,9 @@ end
 
 function _ellipsoid_ab(a::Float64, b::Float64, name, epsg)
     f = 1 - b / a
-    e = sqrt(f * (2 - f))
-    Ellipsoid(a, b, f, e, name, epsg)
+    e2 = f * (2 - f)
+    e = sqrt(e2)
+    Ellipsoid(a, b, f, e, e2, name, epsg)
 end
 function _ellipsoid_af(a::Float64, f_inv::Float64, name, epsg)
     b = a * (1 - inv(f_inv))

--- a/src/epsg.jl
+++ b/src/epsg.jl
@@ -20,6 +20,10 @@ function project_to_4326(epsg::EPSG; T::Type = Float64, kernel::MathKernel = DEF
         PolarStereographicToLonLat{T}(; lat_ts = -71.0, lon_0 = 0.0, kernel)
     elseif code == 3413
         PolarStereographicToLonLat{T}(; lat_ts = 70.0, lon_0 = -45.0, kernel)
+    elseif code == 4978
+        GeocentricToLonLat{T}(; kernel)
+    elseif code == 4979
+        Identity()
     elseif isutm(epsg)
         UTMToLonLat(epsg; T, kernel)
     else
@@ -41,6 +45,10 @@ function project_from_4326(epsg::EPSG; T::Type = Float64, kernel::MathKernel = D
         LonLatToPolarStereographic{T}(; lat_ts = -71.0, lon_0 = 0.0, kernel)
     elseif code == 3413
         LonLatToPolarStereographic{T}(; lat_ts = 70.0, lon_0 = -45.0, kernel)
+    elseif code == 4978
+        LonLatToGeocentric{T}(; kernel)
+    elseif code == 4979
+        Identity()
     elseif isutm(epsg)
         LonLatToUTM(epsg; T, kernel)
     else
@@ -60,7 +68,7 @@ than three -- a CRS added here but not classified in [`isgeographic`](@ref)
 fails the suite instead of quietly returning x and y the wrong way round, and
 one added here without a projection in [`project_to_4326`](@ref) fails too.
 """
-const fast_epsg_codes = (3031, 3413, 4326)
+const fast_epsg_codes = (3031, 3413, 4326, 4978, 4979)
 
 """
     fast_epsgs
@@ -91,7 +99,7 @@ order silently reversed under `always_xy = false` rather than failing, so the
 test suite walks `fast_epsg_codes` and checks each against Proj at both axis
 orders.
 """
-isgeographic(epsg::EPSG) = first(epsg.val) == 4326
+isgeographic(epsg::EPSG) = first(epsg.val) in (4326, 4979)
 
 """
     pipeline(source_epsg, target_epsg; always_xy, proj_only, T, kernel)
@@ -108,6 +116,13 @@ function pipeline(source_epsg::EPSG, target_epsg::EPSG;
     end
     from = project_to_4326(source_epsg; T, kernel)
     to = project_from_4326(target_epsg; T, kernel)
+    # A geocentric source hands the projection after it a `Direction` rather than
+    # a pair of angles, so the trigonometry between the two stages cancels; see
+    # `fuse.jl`. This is the one place the pipeline is not literally `to ∘ from`,
+    # and it is the same function either way.
+    if from isa GeocentricToLonLat && fuses_direction(to) && !isgeographic(target_epsg)
+        return FusedFromGeocentric(from, to)
+    end
     # native projections speak (x, y) / (lon, lat); swap at a geographic end
     # when the caller wants authority order
     if !always_xy

--- a/src/kernels.jl
+++ b/src/kernels.jl
@@ -92,6 +92,7 @@ vectorizes(::BaseKernel) = false
 @inline exp(::BaseKernel, x) = Base.exp(x)
 @inline log(::BaseKernel, x) = Base.log(x)
 @inline pow(::BaseKernel, x, y) = x^y
+@inline cbrt(::BaseKernel, x) = Base.cbrt(x)
 @inline sincos(::BaseKernel, x) = Base.sincos(x)
 @inline sinhcosh(::BaseKernel, x) = (Base.sinh(x), Base.cosh(x))
 
@@ -112,6 +113,7 @@ vectorizes(::BaseKernel) = false
 @inline exp(::SLEEFKernel, x) = SLEEFPirates.exp(x)
 @inline log(::SLEEFKernel, x) = SLEEFPirates.log(x)
 @inline pow(::SLEEFKernel, x, y) = SLEEFPirates.pow(x, y)
+@inline cbrt(::SLEEFKernel, x) = SLEEFPirates.cbrt(x)
 @inline sincos(::SLEEFKernel, x) = SLEEFPirates.sincos(x)
 @inline sinhcosh(::SLEEFKernel, x) = (SLEEFPirates.sinh(x), SLEEFPirates.cosh(x))
 
@@ -132,6 +134,7 @@ vectorizes(::BaseKernel) = false
 @inline exp(::FastKernel, x) = SLEEFPirates.exp(x)
 @inline log(::FastKernel, x) = SLEEFPirates.log_fast(x)
 @inline pow(::FastKernel, x, y) = SLEEFPirates.pow_fast(x, y)
+@inline cbrt(::FastKernel, x) = SLEEFPirates.cbrt_fast(x)
 @inline sincos(::FastKernel, x) = SLEEFPirates.sincos_fast(x)
 
 """

--- a/src/projections/direction.jl
+++ b/src/projections/direction.jl
@@ -1,0 +1,98 @@
+# The geodetic direction, and the protocol a projection implements to accept one.
+#
+# Composing `GeocentricToLonLat` with a projection pays for trigonometry twice
+# over: the geocentric inverse forms `lat = atan(z, d)` and `lon = atan(y, x)`,
+# and the projection immediately takes the sine and cosine of both. Neither
+# needs the angle, only its sine and cosine, and those are available directly
+# from the Cartesian quantities:
+#
+#     sin(lat) = z / hypot(d, z)      cos(lat) = d / hypot(d, z)
+#     sin(lon) = y / hypot(x, y)      cos(lon) = x / hypot(x, y)
+#     tan(lat) = z / d
+#
+# so the pair of `atan`s and the pair of `sincos`es cancel. What passes between
+# the stages instead is `Direction`: the unnormalized geodetic direction, which
+# is what `GeocentricToLonLat` has before it forms an angle and what a
+# projection wants after it has taken one apart.
+#
+# A projection opts in by implementing `project_direction`. The default forms
+# the angles and calls the projection, so a projection that does not implement
+# it still composes correctly -- just without the saving.
+
+"""
+    Direction(d, z, x, y)
+
+The geodetic direction at a point, unnormalized: `atan(z, d)` is its latitude
+and `atan(y, x)` its longitude, but the quotients that a projection actually
+consumes are available without forming either angle.
+
+`d` is the distance from the axis to the point's normal intercept, which is what
+the geocentric inverse computes on the way to a latitude; `x` and `y` are the
+equatorial Cartesian coordinates. The four are not independent -- `hypot(x, y)`
+and `d` differ only by the ellipsoid's curvature correction -- but both are
+needed, `d` for the latitude and `(x, y)` for the longitude.
+"""
+struct Direction{T}
+    d::T
+    z::T
+    x::T
+    y::T
+end
+
+"""
+    sincos_lat(dir)
+
+`(sin, cos)` of the geodetic latitude, without forming the angle.
+"""
+@inline function sincos_lat(dir::Direction)
+    r = sqrt(dir.d * dir.d + dir.z * dir.z)
+    (dir.z / r, dir.d / r)
+end
+
+"""
+    sincos_lon(dir)
+
+`(sin, cos)` of the geodetic longitude, without forming the angle.
+"""
+@inline function sincos_lon(dir::Direction)
+    r = sqrt(dir.x * dir.x + dir.y * dir.y)
+    (dir.y / r, dir.x / r)
+end
+
+"""
+    lat_degrees(dir)
+    lon_degrees(dir)
+
+The geodetic angles in degrees. What the default [`project_direction`](@ref)
+falls back to, and what a projection reaches for where it needs the angle itself
+rather than its sine and cosine -- the reduction against a central meridian in
+[`LonLatToTransverseMercator`](@ref), for one.
+"""
+@inline lat_degrees(dir::Direction{T}) where {T} = atan(dir.z, dir.d) * T(180 / pi)
+@inline lon_degrees(dir::Direction{T}) where {T} = atan(dir.y, dir.x) * T(180 / pi)
+
+"""
+    project_direction(t, dir::Direction)
+
+Apply the projection `t` to a point given as a [`Direction`](@ref) rather than as
+`(lon, lat)`, so that the trigonometry the geocentric stage before it would have
+undone is never performed.
+
+The default forms both angles and calls `t`, which is correct for any
+projection; implementing it is an optimization, and one worth making only for a
+projection whose own first act is to take the sine and cosine of what it was
+given. [`fuses_direction`](@ref) reports whether a projection has.
+"""
+@inline project_direction(t::GeoTransformation, dir::Direction) =
+    t(lon_degrees(dir), lat_degrees(dir))
+
+"""
+    fuses_direction(t)
+
+Whether `t` implements [`project_direction`](@ref) natively, so that composing a
+geocentric stage onto it is worth replacing with [`FusedFromGeocentric`](@ref).
+
+False by default: a projection that has not opted in still composes correctly
+through the fallback, and fusing it would only add a layer.
+"""
+fuses_direction(::GeoTransformation) = false

--- a/src/projections/fuse.jl
+++ b/src/projections/fuse.jl
@@ -1,0 +1,49 @@
+# Replacing a geocentric stage plus a projection with the fused pair.
+#
+# `Direction` and the `project_direction` protocol are in `direction.jl`, which
+# has to precede the projections that implement it; this is the composition
+# built from them, and it needs `GeocentricToLonLat` to exist.
+
+"""
+    FusedFromGeocentric(geo, proj)
+
+`proj ∘ geo` with the trigonometry between them cancelled, where `geo` is a
+[`GeocentricToLonLat`](@ref) and `proj` a projection that implements
+[`project_direction`](@ref).
+
+Built by [`pipeline`](@ref) in place of the composition whenever
+[`fuses_direction`](@ref) holds for `proj`, and behaves identically -- the same
+function to within a few ulps, at roughly half the cost. Takes three
+coordinates, since the geocentric stage consumes a height; returns the
+projection's two plus the geodetic height it recovered.
+"""
+struct FusedFromGeocentric{G<:GeocentricToLonLat,P<:GeoTransformation} <: GeoTransformation
+    geo::G
+    proj::P
+end
+
+@inline function (t::FusedFromGeocentric)(x, y, z)
+    dir, h = geocentric_direction(t.geo, x, y, z)
+    px, py = project_direction(t.proj, dir)
+    (px, py, h)
+end
+
+(t::FusedFromGeocentric)(x, y) = throw(ArgumentError(
+    "$(typeof(t.geo)) transforms (x, y, z); a two-coordinate call would mean z = 0, a point on " *
+    "the equatorial plane. Pass all three coordinates."))
+
+# The height is transformed by the geocentric stage, so it cannot be carried.
+preservesz(::FusedFromGeocentric) = false
+
+islanesafe(t::FusedFromGeocentric) = islanesafe(t.geo) && islanesafe(t.proj)
+
+adapt_eltype(t::FusedFromGeocentric, ::Type{S}) where {S} =
+    FusedFromGeocentric(adapt_eltype(t.geo, S), adapt_eltype(t.proj, S))
+
+# Inverting gives back the ordinary composition: the reverse pipeline is
+# `LonLatToGeocentric ∘ inv(proj)`, and fusing that is the separate question of
+# whether `inv(proj)` can hand a `Direction` forward.
+Base.inv(t::FusedFromGeocentric) = inv(t.geo) ∘ inv(t.proj)
+
+Base.show(io::IO, t::FusedFromGeocentric) =
+    print(io, t.proj, " ∘ ", t.geo, " [fused]")

--- a/src/projections/geocentric.jl
+++ b/src/projections/geocentric.jl
@@ -1,0 +1,162 @@
+# Geodetic to geocentric Cartesian, as a pair of point operators.
+#
+# These are the only operators here that transform a height rather than carry it
+# across: a geocentric z is a Cartesian coordinate, and x and y depend on the
+# height going in. So both directions take and return three coordinates, and
+# `preservesz` is false for them -- see `transformations.jl`.
+#
+# The inverse is Vermeille's 2002 closed form. Geodetic latitude from a
+# Cartesian position has no closed form in the usual sense; this one is exact in
+# the sense that matters, recovering an exactly-computed position to 2e-9 m
+# without iterating, which is what keeps it branch-free and lane-safe. PROJ's own
+# inverse loses accuracy with height -- 4.0e-3 m at 700 km -- so the round trip
+# rather than PROJ is what pins this direction.
+
+"""
+    LonLatToGeocentric(; ellips = ellipsoid(EPSG(7030)), kernel = FastKernel())
+    LonLatToGeocentric{T}(; ...)
+
+Point operator taking geodetic `(lon, lat, height)` -- degrees and metres -- to
+geocentric Cartesian `(x, y, z)` in metres. This is EPSG:4979 to EPSG:4978 on
+WGS 84.
+
+Unlike a map projection, this transforms the height rather than carrying it
+across, so it takes three coordinates and returns three. A two-coordinate call
+would mean a height of zero, which moves x and y by metres, so it is an error
+rather than an implied sea-level point.
+
+    julia> t = LonLatToGeocentric()
+    LonLatToGeocentric{Float64}(WGS_84)
+
+    julia> t(5.39, 52.16, 100.0)
+    (3.9036404612786868e6, 368315.27616670664, 5.013823349039822e6)
+"""
+struct LonLatToGeocentric{T,K<:MathKernel} <: GeoTransformation
+    a::T
+    e2::T
+    one_minus_e2::T   # the polar term of the prime vertical radius, folded once
+    d2r::T
+    name::Union{Nothing,Symbol}
+    kernel::K
+end
+
+"""
+    GeocentricToLonLat(; ellips = ellipsoid(EPSG(7030)), kernel = FastKernel())
+    GeocentricToLonLat{T}(; ...)
+
+Point operator taking geocentric Cartesian `(x, y, z)` in metres to geodetic
+`(lon, lat, height)` in degrees and metres. The inverse of
+[`LonLatToGeocentric`](@ref); see it for why both take three coordinates.
+"""
+struct GeocentricToLonLat{T,K<:MathKernel} <: GeoTransformation
+    a::T
+    e2::T
+    e4::T             # e2^2, and a2 = a^2: both appear in every evaluation
+    a2::T
+    one_minus_e2::T
+    r2d::T
+    name::Union{Nothing,Symbol}
+    kernel::K
+end
+
+function _lonlat_to_geocentric(::Type{T}, a, e2, name, kernel::K) where {T,K}
+    LonLatToGeocentric{T,K}(a, e2, 1 - e2, pi / 180, name, kernel)
+end
+
+function _geocentric_to_lonlat(::Type{T}, a, e2, name, kernel::K) where {T,K}
+    GeocentricToLonLat{T,K}(a, e2, e2^2, a^2, 1 - e2, 180 / pi, name, kernel)
+end
+
+function LonLatToGeocentric{T}(; ellips::Ellipsoid = ellipsoid(EPSG(7030)),
+                                kernel::MathKernel = DEFAULT_KERNEL) where {T}
+    _lonlat_to_geocentric(T, ellips.a, ellips.e2, ellips.name, kernel)
+end
+LonLatToGeocentric(; kwargs...) = LonLatToGeocentric{Float64}(; kwargs...)
+
+function GeocentricToLonLat{T}(; ellips::Ellipsoid = ellipsoid(EPSG(7030)),
+                                kernel::MathKernel = DEFAULT_KERNEL) where {T}
+    _geocentric_to_lonlat(T, ellips.a, ellips.e2, ellips.name, kernel)
+end
+GeocentricToLonLat(; kwargs...) = GeocentricToLonLat{Float64}(; kwargs...)
+
+@inline function (t::LonLatToGeocentric{T})(lon, lat, h) where {T}
+    K = t.kernel
+    slat, clat = Math.sincos(K, lat * t.d2r)
+    slon, clon = Math.sincos(K, lon * t.d2r)
+    # Radius of curvature in the prime vertical.
+    re = t.a / sqrt(1 - t.e2 * slat * slat)
+    ((re + h) * clat * clon,
+     (re + h) * clat * slon,
+     (re * t.one_minus_e2 + h) * slat)
+end
+
+@inline function (t::GeocentricToLonLat{T})(x, y, z) where {T}
+    dir, h = geocentric_direction(t, x, y, z)
+    K = t.kernel
+    (Math.atan(K, dir.y, dir.x) * t.r2d,
+     Math.atan(K, dir.z, dir.d) * t.r2d,
+     h)
+end
+
+"""
+    geocentric_direction(t::GeocentricToLonLat, x, y, z) -> (Direction, height)
+
+Vermeille's solution stopped one step short of the angles: the geodetic
+[`Direction`](@ref) at the point, and the ellipsoidal height.
+
+The height is complete, but the latitude and longitude are still the quotients
+`z/d` and `y/x` rather than the arctangents of them. A projection consumes those
+quotients, so a fused pipeline never forms the angles -- see
+[`project_direction`](@ref). `t` itself forms them, which is the only difference
+between it and this.
+"""
+@inline function geocentric_direction(t::GeocentricToLonLat{T}, x, y, z) where {T}
+    K = t.kernel
+    e2, e4 = t.e2, t.e4
+    lat2 = x * x + y * y
+    # Lateral and polar distances, normalized by the semi-major axis.
+    p = lat2 / t.a2
+    q = (t.one_minus_e2 * z * z) / t.a2
+    r = (p + q - e4) / 6
+    s = (e4 * p * q) / (4 * r * r * r)
+    tt = Math.cbrt(K, 1 + s + sqrt(s * (2 + s)))
+    u = r * (1 + tt + 1 / tt)
+    rv = sqrt(u * u + e4 * q)
+    w = (e2 * (u + rv - q)) / (2 * rv)
+    k = sqrt(u + rv + w * w) - w
+    d = (k * sqrt(lat2)) / (k + e2)
+    h = ((k + e2 - 1) * sqrt(d * d + z * z)) / k
+    (Direction{T}(d, z, x, y), h)
+end
+
+# A height is what these compute, so it cannot be carried across them.
+preservesz(::LonLatToGeocentric) = false
+preservesz(::GeocentricToLonLat) = false
+
+# Two coordinates would mean a height of zero. That is not a sea-level default:
+# it moves x and y by metres, so it is a caller error rather than an assumption
+# to make silently.
+(t::LonLatToGeocentric)(x, y) = throw(ArgumentError(
+    "LonLatToGeocentric transforms (lon, lat, height); a two-coordinate call would mean a height " *
+    "of zero, which moves x and y by metres. Pass a height."))
+(t::GeocentricToLonLat)(x, y) = throw(ArgumentError(
+    "GeocentricToLonLat transforms (x, y, z); a two-coordinate call would mean z = 0, a point on " *
+    "the equatorial plane. Pass all three coordinates."))
+
+Base.inv(t::LonLatToGeocentric{T}) where {T} =
+    _geocentric_to_lonlat(T, t.a, t.e2, t.name, t.kernel)
+Base.inv(t::GeocentricToLonLat{T}) where {T} =
+    _lonlat_to_geocentric(T, t.a, t.e2, t.name, t.kernel)
+
+islanesafe(t::LonLatToGeocentric) = vectorizes(t.kernel)
+islanesafe(t::GeocentricToLonLat) = vectorizes(t.kernel)
+
+adapt_eltype(t::LonLatToGeocentric{T}, ::Type{S}) where {T,S} =
+    T === S ? t : _lonlat_to_geocentric(S, t.a, t.e2, t.name, t.kernel)
+adapt_eltype(t::GeocentricToLonLat{T}, ::Type{S}) where {T,S} =
+    T === S ? t : _geocentric_to_lonlat(S, t.a, t.e2, t.name, t.kernel)
+
+Base.show(io::IO, t::LonLatToGeocentric{T}) where {T} =
+    print(io, "LonLatToGeocentric{$T}(", something(t.name, "a = $(t.a)"), ")")
+Base.show(io::IO, t::GeocentricToLonLat{T}) where {T} =
+    print(io, "GeocentricToLonLat{$T}(", something(t.name, "a = $(t.a)"), ")")

--- a/src/projections/polarstereo.jl
+++ b/src/projections/polarstereo.jl
@@ -25,6 +25,8 @@ struct LonLatToPolarStereographic{T,K<:MathKernel} <: GeoTransformation
     pm::T         # +1 north, -1 south
     ehalf::T      # e/2, hoisted out of the pow
     d2r::T
+    s_lon_0::T    # sine and cosine of the central meridian, for the angle
+    c_lon_0::T    # subtraction a fused pipeline does in place of `sincos`
     kernel::K
 end
 
@@ -74,7 +76,8 @@ end
 # build either direction from the already-reduced parameter set, so that `inv`
 # never has to recover degrees from radians
 function _lonlat_to_ps(::Type{T}, a, e, lon_0, t_c, m_c, pm, kernel::K) where {T,K}
-    LonLatToPolarStereographic{T,K}(a, e, lon_0, t_c, m_c, pm, e / 2, pi / 180, kernel)
+    s0, c0 = sincos(lon_0)
+    LonLatToPolarStereographic{T,K}(a, e, lon_0, t_c, m_c, pm, e / 2, pi / 180, s0, c0, kernel)
 end
 
 function _ps_to_lonlat(::Type{T}, a, e, lon_0, t_c, m_c, pm, kernel::K) where {T,K}
@@ -133,6 +136,31 @@ Base.inv(p::LonLatToPolarStereographic{T}) where {T} =
     _ps_to_lonlat(T, p.a, p.e, p.lon_0, p.t_c, p.m_c, p.pm, p.kernel)
 Base.inv(p::PolarStereographicToLonLat{T}) where {T} =
     _lonlat_to_ps(T, p.a, p.e, p.lon_0, p.t_c, p.m_c, p.pm, p.kernel)
+
+# Everything this projection wants from the geodetic angles is their sines and
+# cosines, so a point arriving as a `Direction` skips both `atan`s that formed
+# them and both `sincos`es that took them apart. `tan(pi/4 - lat/2)` is the
+# half-angle identity `cos/(1 + sin)`, which in Cartesian terms is `d/(R + z)`.
+fuses_direction(::LonLatToPolarStereographic) = true
+
+@inline function project_direction(p::LonLatToPolarStereographic{T},
+                                   dir::Direction) where {T}
+    K = p.kernel
+    # `pm` flips the hemisphere, which in this form is a flip of z's sign.
+    zp = dir.z * p.pm
+    R = sqrt(dir.d * dir.d + zp * zp)
+    s = zp / R
+    t = (dir.d / (R + zp)) /
+        Math.pow(K, (1 - p.e * s) / (1 + p.e * s), p.ehalf)
+    rho = p.a * p.m_c * t / p.t_c
+    # sin and cos of (lon * pm - lon_0), by angle subtraction on the direction's
+    # own sine and cosine against the central meridian's precomputed pair.
+    slon, clon = sincos_lon(dir)
+    slon = slon * p.pm
+    sdl = slon * p.c_lon_0 - clon * p.s_lon_0
+    cdl = clon * p.c_lon_0 + slon * p.s_lon_0
+    (p.pm * rho * sdl, -p.pm * rho * cdl)
+end
 
 islanesafe(p::LonLatToPolarStereographic) = vectorizes(p.kernel)
 islanesafe(p::PolarStereographicToLonLat) = vectorizes(p.kernel)

--- a/src/projections/tranmerc.jl
+++ b/src/projections/tranmerc.jl
@@ -375,29 +375,40 @@ Base.show(io::IO, t::TransverseMercatorToLonLat{T}) where {T} =
 
 @inline function _lonlat_to_tm(t::LonLatToTransverseMercator{T, KT}, lon_in, lat, ::Val{FULL}) where {T, KT, FULL}
     K = t.kernel
+    latsign = _signnz(lat)
+    # Reflected into the first quadrant, so the sine is of |lat| and the sign is
+    # carried separately; `_tm_from_sincos_lat` folds it back at the end.
+    slat, clat = Math.sincos(K, lat * latsign * T(pi / 180))
+    _tm_from_sincos_lat(t, lon_in, slat, clat, latsign, lat == T(90), Val(FULL))
+end
+
+# The projection proper, from the sine and cosine of |latitude| rather than from
+# the latitude: what a fused pipeline supplies without forming the angle. The
+# longitude is still a number of degrees, since `_angdiff` reduces it against the
+# central meridian in compensated arithmetic that a sine and cosine cannot carry.
+@inline function _tm_from_sincos_lat(t::LonLatToTransverseMercator{T, KT}, lon_in,
+                                     slat, clat, latsign, at90, ::Val{FULL}) where {T, KT, FULL}
+    K = t.kernel
     d2r = T(pi / 180)
 
     lon = _angdiff(T, t.lon00, t.lon0, lon_in)
 
-    latsign = _signnz(lat)
     lonsign = _signnz(lon)
     lon = lon * lonsign
-    lat = lat * latsign
 
     # the far side of the central meridian is the near side reflected
     backside = lon > T(90)
-    latsign = ifelse(backside & (lat == zero(lat)), -one(latsign), latsign)
+    latsign = ifelse(backside & (slat == zero(slat)), -one(latsign), latsign)
     lon = ifelse(backside, T(180) - lon, lon)
 
     slam, clam = Math.sincos(K, lon * d2r)
-    slat, clat = Math.sincos(K, lat * d2r)
 
     tau = slat / max(t.fmin, clat)
     tau1 = sqrt(tau * tau + one(tau))
     taup = _taupf(K, tau, tau1, t.e, t.e / 2)
     htc = sqrt(taup * taup + clam * clam)
 
-    atpole = lat == T(90)
+    atpole = at90
     xip = ifelse(atpole, T(pi) / 2, Math.atan(K, taup, clam))
     etap = ifelse(atpole, zero(taup), Math.asinh(K, slam / htc))
 
@@ -591,6 +602,24 @@ end
 
 @inline (t::LonLatToTransverseMercator)(lon, lat) = _lonlat_to_tm(t, lon, lat, Val(false))
 @inline (t::TransverseMercatorToLonLat)(x, y) = _tm_to_lonlat(t, x, y, Val(false))
+
+# Only the latitude fuses. The longitude has to be reduced against the central
+# meridian by `_angdiff`, whose two-term compensated arithmetic is what keeps the
+# result exact at the branch cut, and that works on degrees rather than on a
+# sine and cosine -- an angle-subtraction identity on the direction would lose
+# exactly the low-order part `_angdiff` exists to keep. So the longitude is
+# formed and only `sincos(lat)` is saved, along with one `atan`.
+fuses_direction(::LonLatToTransverseMercator) = true
+
+@inline function project_direction(t::LonLatToTransverseMercator{T,KT},
+                                   dir::Direction) where {T,KT}
+    slat, clat = sincos_lat(dir)
+    # `_tm_from_sincos_lat` works in the first quadrant with the hemisphere
+    # carried separately, so the sine is reflected and its sign handed across.
+    latsign = _signnz(slat)
+    _tm_from_sincos_lat(t, lon_degrees(dir), slat * latsign, clat, latsign,
+                        dir.d == zero(dir.d), Val(false))
+end
 
 """
     convergence_scale(t, x, y) -> (γ, k)

--- a/src/projections/utm.jl
+++ b/src/projections/utm.jl
@@ -101,6 +101,15 @@ UTMToLonLat{T}(epsg::EPSG; kwargs...) where {T} =
     (muladd(x, t.k0, t.fe), muladd(y, t.k0, t.fn))
 end
 
+# The scale and false origin are applied after the projection, so whatever the
+# transverse Mercator underneath can fuse, this can too.
+fuses_direction(t::LonLatToUTM) = fuses_direction(t.tm)
+
+@inline function project_direction(t::LonLatToUTM, dir::Direction)
+    x, y = project_direction(t.tm, dir)
+    (muladd(x, t.k0, t.fe), muladd(y, t.k0, t.fn))
+end
+
 @inline (t::UTMToLonLat)(x, y) =
     t.tm(muladd(x, t.inv_k0, t.dx), muladd(y, t.inv_k0, t.dy))
 

--- a/test/transformations.jl
+++ b/test/transformations.jl
@@ -527,9 +527,19 @@ end
         # source must not reach a path that transforms only x and y.
         @test !isapprox(pj(lon, lat)[1], want[1]; atol = 1.0)
 
-        # ...while x and y alone still transform: there is no height to carry,
-        # and 2D in, 2D out is what such a pipeline is usually asked for.
-        @test all(transform(tz, [(lon, lat)])[1] .≈ pj(lon, lat))
+        # A native operator whose whole subject is the height says so rather than
+        # taking the h = 0 point: there is no height to transform in two
+        # coordinates, and no useful default for one.
+        @test_throws "would mean a height of zero" tz(lon, lat)
+        @test_throws "would mean a height of zero" transform(tz, [(lon, lat)])
+
+        # A Proj-backed pipeline that can change a height still takes x and y
+        # alone, because 2D in and 2D out is a thing Proj resolves and is what
+        # such a pipeline is usually asked for.
+        tp = Transformation(EPSG(4326), EPSG(3857); always_xy = true)
+        @test !FastGeoProjections.preservesz(tp)
+        @test all(transform(tp, [(lon, lat)])[1] .≈
+                  Proj.Transformation("EPSG:4326", "EPSG:3857"; always_xy = true)(lon, lat))
 
         # A map projection is a function of x and y, so it does preserve one.
         @test FastGeoProjections.preservesz(Transformation(EPSG(4326), EPSG(3413)))
@@ -657,7 +667,15 @@ end
                 # `always_xy` decides which way round the input is read, so
                 # feed both the same pair and let them disagree if it does
                 a, b = always_xy ? (lon, lat) : (lat, lon)
-                @test all(isapprox.(ours(a, b), pj(a, b); rtol = 1e-6))
+                # A CRS that transforms a height has none to transform from a
+                # two-coordinate call and rejects one, so it is fed three. Proj
+                # reads (lat, lon, h) in authority order just as it reads
+                # (lat, lon), so the height goes last either way.
+                if FastGeoProjections.preservesz(ours)
+                    @test all(isapprox.(ours(a, b), pj(a, b); rtol = 1e-6))
+                else
+                    @test all(isapprox.(ours(a, b, 100.0), pj(a, b, 100.0); rtol = 1e-6))
+                end
             end
         end
     end
@@ -689,5 +707,260 @@ end
         @test_throws ArgumentError transform!(t, [1, 2, 3])
         @test_throws DimensionMismatch transform!(Vector{NTuple{2,Float64}}(undef, 2),
                                                   t, mk(Tuple))
+    end
+end
+
+@testset "geocentric" begin
+    fwd = LonLatToGeocentric()
+    inverse = GeocentricToLonLat()
+    pj = Proj.Transformation("EPSG:4979", "EPSG:4978"; always_xy = true)
+
+    # Heights from below sea level to satellite altitude: the operator is used at
+    # orbit as well as on the ground, and the inverse's accuracy is the thing
+    # that varies with height.
+    cases = [(lo, la, h) for la in -85.0:17.0:85.0, lo in -175.0:35.0:175.0,
+                             h in (-500.0, 0.0, 1e3, 8e3, 7e5)]
+
+    @testset "forward agrees with Proj" begin
+        worst = 0.0
+        for (lo, la, h) in cases
+            worst = max(worst, maximum(abs.(fwd(lo, la, h) .- pj(lo, la, h))))
+        end
+        @test worst < 1e-8
+    end
+
+    @testset "the round trip closes at every height" begin
+        # Proj's own inverse is 4.0e-3 m out at 700 km, so above the troposphere
+        # the round trip rather than Proj is what pins the inverse.
+        worst_h = 0.0
+        worst_ground = 0.0
+        for (lo, la, h) in cases
+            xyz = fwd(lo, la, h)
+            back = inverse(xyz...)
+            worst_h = max(worst_h, abs(back[3] - h))
+            worst_ground = max(worst_ground, maximum(abs.(fwd(back...) .- xyz)))
+        end
+        @test worst_h < 1e-8
+        @test worst_ground < 1e-8
+    end
+
+    @testset "inverse agrees with Proj below satellite altitude" begin
+        # The round trip above cannot catch an error the two directions share --
+        # a wrong `e2` would close it perfectly -- so the inverse is compared to
+        # an independent implementation as well. Confined to heights where Proj's
+        # own inverse is trustworthy: at 700 km it is 4.0e-3 m out, which is why
+        # the round trip is what covers the rest.
+        pj_i = Proj.Transformation("EPSG:4978", "EPSG:4979"; always_xy = true)
+        worst_horiz = 0.0
+        worst_h = 0.0
+        for la in -89.0:2.0:89.0, lo in -179.0:6.0:179.0, h in (-400.0, 0.0, 3e3, 1e4)
+            xyz = pj(lo, la, h)
+            got = inverse(xyz...)
+            want = pj_i(xyz...)
+            # Angles as ground distance, which is comparable across latitudes.
+            worst_horiz = max(worst_horiz, abs(got[2] - want[2]) * 111320,
+                              abs(got[1] - want[1]) * 111320 * cosd(la))
+            worst_h = max(worst_h, abs(got[3] - want[3]))
+        end
+        @test worst_horiz < 1e-5
+        @test worst_h < 1e-5
+    end
+
+    @testset "the poles and the antimeridian" begin
+        # Where a projection breaks if it is going to. A pole has no defined
+        # longitude, so only the latitude and the height are compared there.
+        pj_i = Proj.Transformation("EPSG:4978", "EPSG:4979"; always_xy = true)
+        for (lo, la, lbl) in ((0.0, 90.0, "north pole"), (0.0, -90.0, "south pole"),
+                              (180.0, 45.0, "antimeridian"), (-180.0, 45.0, "antimeridian west"),
+                              (179.9999, 0.0, "just inside the antimeridian"),
+                              (0.0, 0.0, "origin"))
+            want = pj(lo, la, 100.0)
+            @test all(isapprox.(fwd(lo, la, 100.0), want; atol = 1e-6))
+
+            got = inverse(want...)
+            ref = pj_i(want...)
+            @test got[2] ≈ ref[2] atol = 1e-9
+            @test got[3] ≈ ref[3] atol = 1e-6
+            abs(la) > 89.999 || @test got[1] ≈ ref[1] atol = 1e-9
+        end
+    end
+
+    @testset "every kernel and precision against Proj" begin
+        # Only the default is exercised elsewhere. `FastKernel` is the default and
+        # costs about twice the error of the other two, which is the trade it
+        # exists to make; all three are far inside any tolerance that matters.
+        for (K, tol, lbl) in ((BaseKernel(), 1e-9, "Base"),
+                              (SLEEFKernel(), 1e-9, "SLEEF"),
+                              (FastKernel(), 1e-8, "Fast"))
+            f = LonLatToGeocentric(kernel = K)
+            worst = 0.0
+            for la in -85.0:5.0:85.0, lo in -175.0:15.0:175.0
+                worst = max(worst, maximum(abs.(f(lo, la, 100.0) .- pj(lo, la, 100.0))))
+            end
+            @test worst < tol
+        end
+
+        # Float32 is bounded by its own representable resolution at this
+        # magnitude -- `eps(Float32) * 6.4e6` is about 0.76 m -- not by the
+        # projection. Asserted so that the cost of asking for it is on record.
+        f32 = LonLatToGeocentric{Float32}()
+        worst32 = 0.0
+        for la in -85.0:5.0:85.0, lo in -175.0:15.0:175.0
+            worst32 = max(worst32,
+                          maximum(abs.(Float64.(f32(Float32(lo), Float32(la), 100.0f0)) .-
+                                       pj(lo, la, 100.0))))
+        end
+        @test 0.1 < worst32 < 5.0
+        @test worst32 > eps(Float32) * 6.4e6 / 2
+    end
+
+    @testset "a height is transformed, not carried" begin
+        @test !FastGeoProjections.preservesz(fwd)
+        @test !FastGeoProjections.preservesz(inverse)
+        for threaded in (false, true)
+            o = transform(fwd, [(5.39, 52.16, 100.0)]; threaded)
+            @test all(o[1] .≈ pj(5.39, 52.16, 100.0))
+            @test o[1][3] != 100.0
+        end
+    end
+
+    @testset "two coordinates are refused, not read as h = 0" begin
+        # The h = 0 point is 61 m away in x here, so there is no defensible
+        # default and the call is an error.
+        @test_throws "would mean a height of zero" fwd(5.39, 52.16)
+        @test_throws "z = 0" inverse(3.9e6, 3.7e5)
+        @test !isapprox(pj(5.39, 52.16)[1], pj(5.39, 52.16, 100.0)[1]; atol = 1.0)
+    end
+
+    @testset "inv, precision and kernel" begin
+        @test inv(fwd) isa GeocentricToLonLat
+        @test inv(inverse) isa LonLatToGeocentric
+        @test all(inv(fwd)(fwd(5.39, 52.16, 100.0)...) .≈ (5.39, 52.16, 100.0))
+
+        f32 = LonLatToGeocentric{Float32}(kernel = BaseKernel())
+        @test inv(f32) isa GeocentricToLonLat{Float32}
+        @test inv(f32).kernel isa BaseKernel
+        @test !FastGeoProjections.islanesafe(LonLatToGeocentric(kernel = BaseKernel()))
+        @test FastGeoProjections.islanesafe(fwd)
+    end
+
+    @testset "through the EPSG registry" begin
+        for (s, t) in ((4979, 4978), (4978, 4979))
+            ours = Transformation(EPSG(s), EPSG(t); always_xy = true)
+            theirs = Proj.Transformation("EPSG:$s", "EPSG:$t"; always_xy = true)
+            @test FastGeoProjections.isfastepsg(EPSG(s))
+            @test !FastGeoProjections.preservesz(ours)
+            args = s == 4979 ? (5.39, 52.16, 100.0) :
+                               (3.9036404612786868e6, 368315.27616670664, 5.013823349039822e6)
+            @test all(isapprox.(ours(args...), theirs(args...); rtol = 1e-9))
+        end
+
+        # Geocentric to a 2-D projected CRS: the height is consumed by the
+        # geocentric stage, and what reaches the projection is the geodetic
+        # (lon, lat) it implies.
+        ours = Transformation(EPSG(4978), EPSG(3413); always_xy = true)
+        theirs = Proj.Transformation("EPSG:4978", "EPSG:3413"; always_xy = true)
+        xyz = (3.9036404612786868e6, 368315.27616670664, 5.013823349039822e6)
+        @test all(isapprox.(ours(xyz...)[1:2], theirs(xyz...)[1:2]; rtol = 1e-9))
+    end
+
+    @testset "fusing the geocentric stage into the projection" begin
+        ll2xyz = Proj.Transformation("EPSG:4979", "EPSG:4978"; always_xy = true)
+
+        # The registry returns the fused operator where the projection accepts a
+        # Direction, and the plain composition where it does not.
+        @test Transformation(EPSG(4978), EPSG(3413)).f isa
+              FastGeoProjections.FusedFromGeocentric
+        @test Transformation(EPSG(4978), EPSG(32619)).f isa
+              FastGeoProjections.FusedFromGeocentric
+        # ...and geographic targets still go through the ordinary path, since
+        # there is no projection to fuse into.
+        @test !(Transformation(EPSG(4978), EPSG(4979)).f isa
+                FastGeoProjections.FusedFromGeocentric)
+
+        @testset "$lbl" for (code, proj, lbl, lons) in (
+                (3413, LonLatToPolarStereographic(; lat_ts = 70.0, lon_0 = -45.0),
+                 "polar stereographic north", -175.0:25.0:175.0),
+                (3031, LonLatToPolarStereographic(; lat_ts = -71.0, lon_0 = 0.0),
+                 "polar stereographic south", -175.0:25.0:175.0),
+                # A transverse Mercator zone is only meaningful near its own
+                # meridian; far outside it the projection diverges, composed as
+                # well as fused. So each zone is swept over its own ±18°.
+                (32601, LonLatToUTM(1, true), "UTM zone 1N",
+                 FastGeoProjections.utm_lon0(1) .+ (-18.0:6.0:18.0)),
+                (32619, LonLatToUTM(19, true), "UTM zone 19N",
+                 FastGeoProjections.utm_lon0(19) .+ (-18.0:6.0:18.0)),
+                (32631, LonLatToUTM(31, true), "UTM zone 31N",
+                 FastGeoProjections.utm_lon0(31) .+ (-18.0:6.0:18.0)),
+                (32660, LonLatToUTM(60, true), "UTM zone 60N",
+                 FastGeoProjections.utm_lon0(60) .+ (-18.0:6.0:18.0)),
+                (32701, LonLatToUTM(1, false), "UTM zone 1S",
+                 FastGeoProjections.utm_lon0(1) .+ (-18.0:6.0:18.0)),
+                (32733, LonLatToUTM(33, false), "UTM zone 33S",
+                 FastGeoProjections.utm_lon0(33) .+ (-18.0:6.0:18.0)),
+                (32760, LonLatToUTM(60, false), "UTM zone 60S",
+                 FastGeoProjections.utm_lon0(60) .+ (-18.0:6.0:18.0)))
+            fused = Transformation(EPSG(4978), EPSG(code); always_xy = true)
+            composed = proj ∘ GeocentricToLonLat()
+            pj = Proj.Transformation("EPSG:4978", "EPSG:$code"; always_xy = true)
+
+            worst_c = 0.0
+            worst_p = 0.0
+            for la in -80.0:10.0:80.0, lo in lons, h in (-200.0, 0.0, 5e3)
+                xyz = ll2xyz(lo, la, h)
+                f = fused(xyz...)
+                # The fused operator is the composition with identities applied,
+                # so it is the same function to a few ulps rather than an
+                # approximation of it.
+                worst_c = max(worst_c, maximum(abs.(f[1:2] .- composed(xyz...)[1:2])))
+                worst_p = max(worst_p, maximum(abs.(f[1:2] .- pj(xyz...)[1:2])))
+                # the height comes back from the geocentric stage either way
+                @test f[3] ≈ h atol = 1e-6
+            end
+            @test worst_c < 1e-6
+            @test worst_p < 1e-5
+        end
+
+        @testset "properties carry through the fusion" begin
+            f = Transformation(EPSG(4978), EPSG(3413); always_xy = true).f
+            @test !FastGeoProjections.preservesz(f)
+            @test FastGeoProjections.islanesafe(f)
+            @test !FastGeoProjections.islanesafe(
+                FastGeoProjections.FusedFromGeocentric(
+                    GeocentricToLonLat(kernel = BaseKernel()),
+                    LonLatToPolarStereographic(; lat_ts = 70.0, lon_0 = -45.0)))
+            # Two coordinates would mean a point on the equatorial plane.
+            @test_throws "z = 0" f(3.9e6, 3.7e5)
+            # Inverting gives the reverse pipeline, an ordinary composition:
+            # `PolarStereographicToLonLat` produces angles and `LonLatToGeocentric`
+            # consumes them, so there is no Direction to hand across. It closes
+            # the round trip, and needs the height that the forward one returned.
+            xyz = (3.9036404612786868e6, 368315.27616670664, 5.013823349039822e6)
+            @test !FastGeoProjections.preservesz(inv(f))
+            @test all(isapprox.(inv(f)(f(xyz...)...), xyz; rtol = 1e-9))
+        end
+
+        @testset "a projection that does not fuse still composes" begin
+            # The fallback forms the angles and calls the projection, so a
+            # projection that has not opted in gives the same answer.
+            @test !FastGeoProjections.fuses_direction(GeocentricToLonLat())
+            dir, h = FastGeoProjections.geocentric_direction(
+                GeocentricToLonLat(), 3.9036404612786868e6, 368315.27616670664,
+                5.013823349039822e6)
+            p = LonLatToPolarStereographic(; lat_ts = 70.0, lon_0 = -45.0)
+            @test all(FastGeoProjections.project_direction(p, dir) .≈
+                      p(FastGeoProjections.lon_degrees(dir),
+                        FastGeoProjections.lat_degrees(dir)))
+            @test h ≈ 100.0 atol = 1e-6
+        end
+    end
+
+    @testset "a non-WGS84 ellipsoid" begin
+        grs80 = LonLatToGeocentric(ellips = FastGeoProjections.ellipsoid(EPSG(7019)))
+        @test grs80.a == 6378137.0
+        # GRS 1980 and WGS 84 differ in flattening only, by 1e-11 relative in e2,
+        # so the positions differ by millimetres rather than not at all.
+        d = maximum(abs.(grs80(5.39, 52.16, 100.0) .- fwd(5.39, 52.16, 100.0)))
+        @test 0 < d < 1e-2
     end
 end


### PR DESCRIPTION
EPSG:4978 and EPSG:4979 are now native. `LonLatToGeocentric` and `GeocentricToLonLat` transform a height rather than carrying one across, so they take three coordinates and reject two — the two-coordinate call is the `h = 0` point, which moves x and y by tens of metres. `Ellipsoid` gains a stored `e2`, computed as `f * (2 - f)` rather than by squaring `e` back up.

### Fusion

Composing a geocentric stage with a projection pays for trigonometry twice: the geocentric inverse forms `atan(z, d)` and `atan(y, x)`, and the projection immediately takes the sine and cosine of both. `Direction` carries the unnormalized direction between them instead, and a projection implementing `project_direction` consumes it without an angle ever being formed. `pipeline` substitutes `FusedFromGeocentric` wherever that holds, so an EPSG pair benefits with no change at the call site; a projection that hasn't opted in still composes through the fallback.

| pipeline | composed | fused | speedup |
|---|---|---|---|
| ECEF → polar stereographic | 119.0 ns | **50.4 ns** | 2.36× |
| ECEF → UTM | 228.5 ns | **186.3 ns** | 1.23× |

Polar stereographic fuses completely: `sin(lat) = z/R`, `tan(π/4 − lat/2) = d/(R + z)`, and the longitude reduces by angle subtraction against a precomputed `sincos(lon_0)`. Transverse Mercator fuses in latitude only, because reducing its longitude goes through `_angdiff`, whose compensated arithmetic keeps the result exact at the branch cut and which a sine and cosine cannot carry.

### Accuracy

| check | result |
|---|---|
| forward vs PROJ | 1.9e-9 m |
| inverse vs PROJ, h ≤ 10 km | 8.9e-7 m |
| round trip, to 700 km | 2.3e-9 m |
| fused vs composed | 3.7e-9 m |
| fused vs PROJ, polar stereographic | 2.0e-6 m |
| fused vs PROJ, UTM, 7 zones both hemispheres | 2.1e-7 m |

Above the troposphere PROJ is the less accurate of the two — 4.0e-3 m at 700 km — so the round trip rather than PROJ pins the inverse at satellite altitude. The poles, the antimeridian, all three math kernels and `Float32` are each checked against PROJ.

The inverse's cube root is `Math.cbrt`, new to the Math kernels.

### Known limitation

`_transform_pts!` sends any height-transforming operator down the scalar loop, so these never reach the SIMD path despite `islanesafe` being true for them. The operator does 4.9 ns/point on 8 lanes against 16.2 scalar, so roughly 2.3× is unclaimed on array calls. Correct, not yet fast; a 3-coordinate interleaved lane loop is the fix.

Co-authored-by: Claude <noreply@anthropic.com>
