### PR TITLE
Replace the isometric-latitude pow with a series

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,136 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this package is
+
+Native-Julia coordinate transformations between EPSG-coded CRSs, faster than Proj for the
+projections it implements and delegating to `Proj.jl` for everything else. Not a Proj replacement:
+`fast_epsg_codes` in `src/epsg.jl` is the whole native set — 3031, 3413, 4326, 4978, 4979, plus UTM
+326XX/327XX.
+
+Accuracy is defined against Proj. Every native projection is asserted against it in the test suite,
+to 5.5e-9 m for UTM and ~2e-9 m for the geocentric conversions.
+
+## Commands
+
+```bash
+julia --project=. -e 'import Pkg; Pkg.test()'                    # full suite
+julia --project=. --threads=8 -e 'import Pkg; Pkg.test()'        # threading paths need >1 thread
+
+# single test file
+julia --project=. -e 'using TestEnv; TestEnv.activate(); include("test/transformations.jl")'
+```
+
+CI runs 1.10 and nightly on ubuntu with `JULIA_NUM_THREADS=4`. No docs project, no formatter.
+
+The committed `benchmark/` project pulls GLMakie, which will not precompile headless — for
+benchmarking, make a scratch environment with `Pkg.develop(path=".")` plus BenchmarkTools rather
+than using `--project=benchmark`. `benchmark/benchmark.jl` and the `benchmark.jpg` in the README
+predate the point-operator restructure and no longer run.
+
+## Architecture
+
+A transformation is a **point operator**: a callable struct holding everything derived from the
+projection parameters, mapping one point to one point. Threading and vectorization live in
+`apply.jl`, not in the projections, so there is one implementation of each projection rather than
+one per calling convention.
+
+- `transformations.jl` — `abstract type GeoTransformation`, the traits every operator answers
+  (`islanesafe`, `preservesz`, `adapt_eltype`), and `ComposedGeoTransformation`, a flat tuple that
+  inlines into one pass.
+- `apply.jl` — `transform`/`transform!` over collections. Picks a SIMD lane loop or a scalar loop
+  per chunk, threads over chunks, and decides how a third coordinate is handled.
+- `epsg.jl` — the EPSG registry. `pipeline()` composes `project_from_4326` with `project_to_4326`,
+  since every projection is expressed relative to EPSG:4326 in (lon, lat) order.
+- `coord.jl` — `Transformation`, the public entry point, wrapping an operator plus the EPSG pair
+  and flags. Implements the CoordinateTransformations API.
+- `proj.jl` — `ProjTransformation`, the fallback. Holds one cloned PROJ context per thread in a
+  `Channel` pool, checked out via `borrow` once per chunk (a context is single-thread-only).
+- `kernels.jl` — the `Math` submodule: `sin`, `cos`, `pow`, `cbrt`, … each taking a `MathKernel`
+  first argument, dispatching to SLEEFPirates' `_fast` routines (`FastKernel`, the default), its
+  fully-reduced ones (`SLEEFKernel`), or Base's libm (`BaseKernel`). These are plain Julia, so they
+  inline into an operator and evaluate on `Vec` lanes as well as scalars — that is what lets a
+  point operator reach array-kernel throughput.
+- `projections/` — one file per projection family, each a `LonLatTo…`/`…ToLonLat` pair.
+
+### Adding a projection
+
+Add branches to both `project_to_4326` and `project_from_4326` in `epsg.jl` (marked by the
+`## ⬇ ADD FAST PROJECTIONS HERE ⬇ ##` comment), append the code to `fast_epsg_codes`, and classify
+it in `isgeographic`. The test suite walks `fast_epsg_codes` and checks each against Proj at both
+axis orders, so an unclassified code fails rather than silently returning x and y reversed.
+
+## Conventions specific to this code
+
+- **EPSG codes hold a tuple**, not a scalar — read them as `first(epsg.val)`.
+- **`always_xy` differs by layer.** `false` on `Transformation` (authority order, so EPSG:4326 is
+  lat, lon); the operators underneath are *always* xy. Axis order is handled by composing `SwapXY`
+  onto the geographic end of a pipeline, not by a per-point branch.
+- **`islanesafe` and `preservesz` are independent traits.** Lane-safe means evaluable on `Vec`
+  lanes; `preservesz` means a third coordinate passes through untouched. A map projection is both;
+  the geocentric conversions are lane-safe but transform the height. Code that conflates them takes
+  the wrong path silently.
+- **A height is transformed, not carried, where the transformation changes one.** For a datum shift
+  or a geocentric conversion, the two-coordinate call is the `h = 0` point — which moves x and y by
+  metres — so `LonLatToGeocentric` and `GeocentricToLonLat` reject it rather than assume sea level.
+- **Fusion.** Composing `GeocentricToLonLat` with a projection would form `atan(z, d)` and
+  `atan(y, x)` and then immediately take their sines and cosines. `Direction` (`projections/direction.jl`)
+  carries the unnormalized direction instead, a projection opts in with `project_direction`, and
+  `pipeline` substitutes `FusedFromGeocentric`. This is the one place a pipeline is not literally
+  `to ∘ from`.
+- **`tranmerc.jl` is written for the compiler, not the reader.** Branches are `ifelse` and boolean
+  arithmetic so the body vectorizes; the Clenshaw recurrences are spelled out rather than looped.
+  `_angdiff`'s two-term compensated arithmetic is load-bearing at the ±180° branch cut and cannot
+  be replaced by an angle-subtraction identity — which is why transverse Mercator fuses in latitude
+  only.
+- `@inbounds` in `apply.jl`'s lane and scalar loops is deliberate and the indices are derived from
+  `eachindex`/lane masks. Don't add more without a benchmark.
+
+## Performance notes
+
+Measured on aarch64 (M-series), 1 thread, 100k points, out of place:
+
+| pipeline | ns/point |
+|---|---|
+| 4326→3413 polar stereographic | ~10 |
+| 4326→32619 UTM | ~48 |
+| 4978→3413 fused geocentric | ~34 |
+
+Two things to know before optimizing:
+
+- **`pick_vector_width(Float64)` is 2 on aarch64**, not 8. A `VecUnroll{U,2}` in a `@code_warntype`
+  dump is an unroll factor, not a lane count. Per-lane speedups are 1.7–2.3×, not 8×.
+- **Run-to-run noise on the array paths is about ±8%.** A single measurement showing a 5%
+  improvement has measured nothing. Repeat a baseline three times before believing any variant.
+
+`transform!` is allocation-free in place; out-of-place allocation is the destination array alone.
+The scalar operators are type-stable with zero JET optimization reports.
+
+**A general `pow` does not vectorize, and it caps a projection's throughput.** `Math.pow` costs
+about five times any other transcendental in a loop, and `code_llvm` on that loop contains no
+`<2 x double>` at all where the same loop over `Math.conformal_ratio` contains 25.
+
+The cause is composition, not the function. `SLEEFPirates.pow_fast` is one line —
+`exp2(y * log2_fast(x))` — and both halves vectorize alone: 1.83 and 1.46 ns/point separately, 3.34
+in two passes over an array, but 6.55 fused into one loop and 10.28 through `pow_fast`. LLVM will
+not vectorize a loop body holding both inlined. Nothing upstream can fix that, because a correct
+general `pow` has to handle negative bases, integer exponents and the infinities, and is therefore
+always too large to vectorize.
+
+`Math.conformal_ratio` wins by not being general: `e < 0.09` and `|u| ≤ e` mean no range reduction
+and no special cases, so twelve fused multiply-adds reach one ulp. Prefer a short series over
+`Math.pow` wherever an exponent is fixed and its argument range is bounded — and check the IR for
+`<2 x double>` rather than trusting a timing, since the array-path noise band swallows anything
+under about 8%.
+
+### Known gaps
+
+- **A height-transforming operator never reaches the SIMD lane loop.** `_transform_pts!` sends it
+  to the scalar path, because the interleaved loop writes rows 1 and 2 and preserves the rest. The
+  cost is small — geocentric on the scalar path is ~12 ns/point, faster than any 2-D operator on
+  the lane path — but a 3-coordinate lane loop would recover roughly 2× on that operator.
+- **`_lane_range_aos!` is not worth tuning.** Running `Identity` through it measures 0.68–0.81
+  ns/point, so the loop is ~4% of a projection's runtime and the strided AoS load costs 0.44
+  ns/point over the contiguous SoA one. `UNROLL` (2/4/8/16) and `CHUNK` are all inside the noise
+  band. Time is in the projection math.

--- a/benchmark/optimize_bench.jl
+++ b/benchmark/optimize_bench.jl
@@ -1,0 +1,89 @@
+# Throughput harness for the optimization pass: one row per (operator, call shape),
+# reported as ns/point so array and scalar paths are comparable.
+#
+# Run as `julia --project=. --threads=8 benchmark/optimize_bench.jl [label]`.
+# Results and the numerical snapshot are serialized next to this file so a later
+# run can be compared without re-measuring the baseline.
+
+using FastGeoProjections
+using BenchmarkTools
+using Serialization
+using Printf
+using StaticArrays
+
+const N = 100_000
+const LABEL = isempty(ARGS) ? "run" : ARGS[1]
+const OUT = joinpath(@__DIR__, "optimize_$(LABEL).jls")
+
+lons = collect(range(-179.0, 179.0; length = N))
+lats = collect(range(-84.0, 84.0; length = N))
+hs = collect(range(-400.0, 8000.0; length = N))
+
+# every case is (name, thunk, npoints); thunks close over interpolated data
+function cases()
+    utm = LonLatToUTM(19, true)
+    ps = LonLatToPolarStereographic(; lat_ts = 70.0, lon_0 = -45.0)
+    geo = LonLatToGeocentric()
+    igeo = GeocentricToLonLat()
+    fused = Transformation(EPSG(4978), EPSG(3413); always_xy = true).f
+
+    xy2 = [(lo, la) for (lo, la) in zip(lons, lats)]
+    xy3 = [(lo, la, h) for (lo, la, h) in zip(lons, lats, hs)]
+    sv3 = [SVector(lo, la, h) for (lo, la, h) in zip(lons, lats, hs)]
+    ecef = [geo(lo, la, h) for (lo, la, h) in zip(lons, lats, hs)]
+
+    [
+     # 2-D operators, array path: the SIMD reference point
+     ("utm  array 2d", () -> transform(utm, xy2), N),
+     ("ps   array 2d", () -> transform(ps, xy2), N),
+     ("utm  soa 2d", () -> transform(utm, lons, lats), N),
+     # height-transforming operators, array path
+     ("geo  array 3d", () -> transform(geo, xy3), N),
+     ("geo  array 3d SVector", () -> transform(geo, sv3), N),
+     ("igeo array 3d", () -> transform(igeo, ecef), N),
+     ("fused array 3d", () -> transform(fused, ecef), N),
+     # scalar, for reference
+     ("utm  scalar", () -> utm(-69.0, 45.0), 1),
+     ("ps   scalar", () -> ps(-45.0, 70.0), 1),
+     ("geo  scalar", () -> geo(5.39, 52.16, 100.0), 1),
+     ("igeo scalar", () -> igeo(3.9036404612786868e6, 368315.27616670664, 5.013823349039822e6), 1),
+     ("fused scalar", () -> fused(3.9036404612786868e6, 368315.27616670664, 5.013823349039822e6), 1),
+    ]
+end
+
+# A digest of what each case computed, so a later run can be checked for
+# equivalence rather than only for speed.
+function snapshot()
+    geo = LonLatToGeocentric()
+    igeo = GeocentricToLonLat()
+    fused = Transformation(EPSG(4978), EPSG(3413); always_xy = true).f
+    utm = LonLatToUTM(19, true)
+    ps = LonLatToPolarStereographic(; lat_ts = 70.0, lon_0 = -45.0)
+    idx = 1:997:N
+    Dict(
+        "utm" => [utm(lons[i], lats[i]) for i in idx],
+        "ps" => [ps(lons[i], lats[i]) for i in idx],
+        "geo" => [geo(lons[i], lats[i], hs[i]) for i in idx],
+        "igeo" => [igeo(geo(lons[i], lats[i], hs[i])...) for i in idx],
+        "fused" => [fused(geo(lons[i], lats[i], hs[i])...) for i in idx],
+    )
+end
+
+function main()
+    results = Dict{String,NamedTuple{(:ns_per_point, :allocs, :bytes),Tuple{Float64,Int,Int}}}()
+    for (name, f, np) in cases()
+        f()                                     # warm up
+        # `evals=1` on a sub-100 ns scalar call measures the timer, not the
+        # call, so a scalar case is evaluated many times per sample.
+        b = np == 1 ? (@benchmark $f() samples=200 evals=1000) :
+                      (@benchmark $f() samples=200 evals=1)
+        m = minimum(b)
+        results[name] = (ns_per_point = m.time / np, allocs = m.allocs, bytes = m.memory)
+        @printf("%-24s %9.2f ns/pt  %6d allocs  %9d B\n", name, m.time / np, m.allocs, m.memory)
+    end
+    serialize(OUT, (results = results, snapshot = snapshot(),
+                    threads = Threads.nthreads()))
+    println("\nwrote ", OUT, "  (", Threads.nthreads(), " threads)")
+end
+
+main()

--- a/src/kernels.jl
+++ b/src/kernels.jl
@@ -138,6 +138,49 @@ vectorizes(::BaseKernel) = false
 @inline sincos(::FastKernel, x) = SLEEFPirates.sincos_fast(x)
 
 """
+    conformal_ratio(kernel, e, u)
+
+`((1 − u) / (1 + u))^(e/2)`, for `u = e·sin(φ)` on an ellipsoid of eccentricity
+`e` — the isometric-latitude factor both the polar stereographic and transverse
+Mercator projections need, and `exp(−e·atanh(u))` written so that it vectorizes.
+
+A general `pow` is the wrong instrument here. It costs about five times any
+other transcendental in a loop, and that loop does not vectorize at all: LLVM
+will not vectorize a body holding both halves of `pow_fast`'s
+`exp2(y * log2_fast(x))` inlined, though each half vectorizes on its own. So a
+`pow` caps a projection's throughput however well the loop around it is written,
+and no general implementation can avoid it — handling negative bases, integer
+exponents and the infinities is what makes one too large to vectorize.
+
+Neither series needs many terms, because both arguments are small. Ellipsoids in
+use have `e < 0.09`, so `|u| ≤ e` bounds `atanh`'s odd series in `u²`, and the
+resulting `|e·atanh(u)| < 7e-3` bounds `exp`'s. Six terms each reach one ulp
+across the whole range, in twelve fused multiply-adds with no branch, no table
+and no exponent manipulation.
+
+The `e < 0.09` bound is the contract. Every ellipsoid in [`ellipsoid`](@ref)
+satisfies it by a wide margin — Earth's flattening is 1/298 — and so does any
+plausible addition, but a genuinely eccentric body would need more terms and is
+outside what this is derived for.
+"""
+@inline function conformal_ratio(K::MathKernel, e, u)
+    v = u * u
+    # atanh(u) / u, in v = u²
+    b = muladd(v, oftype(v, 1 / 11), oftype(v, 1 / 9))
+    b = muladd(v, b, oftype(v, 1 / 7))
+    b = muladd(v, b, oftype(v, 1 / 5))
+    b = muladd(v, b, oftype(v, 1 / 3))
+    b = muladd(v, b, one(v))
+    w = -e * u * b
+    # exp(w)
+    p = muladd(w, oftype(w, 1 / 120), oftype(w, 1 / 24))
+    p = muladd(w, p, oftype(w, 1 / 6))
+    p = muladd(w, p, oftype(w, 1 / 2))
+    p = muladd(w, p, one(w))
+    muladd(w, p, one(w))
+end
+
+"""
     sinhcosh(kernel, x)
 
 Both hyperbolic functions of `x`.

--- a/src/projections/polarstereo.jl
+++ b/src/projections/polarstereo.jl
@@ -23,7 +23,6 @@ struct LonLatToPolarStereographic{T,K<:MathKernel} <: GeoTransformation
     t_c::T        # Snyder's t and m at the standard parallel
     m_c::T
     pm::T         # +1 north, -1 south
-    ehalf::T      # e/2, hoisted out of the pow
     d2r::T
     s_lon_0::T    # sine and cosine of the central meridian, for the angle
     c_lon_0::T    # subtraction a fused pipeline does in place of `sincos`
@@ -77,7 +76,7 @@ end
 # never has to recover degrees from radians
 function _lonlat_to_ps(::Type{T}, a, e, lon_0, t_c, m_c, pm, kernel::K) where {T,K}
     s0, c0 = sincos(lon_0)
-    LonLatToPolarStereographic{T,K}(a, e, lon_0, t_c, m_c, pm, e / 2, pi / 180, s0, c0, kernel)
+    LonLatToPolarStereographic{T,K}(a, e, lon_0, t_c, m_c, pm, pi / 180, s0, c0, kernel)
 end
 
 function _ps_to_lonlat(::Type{T}, a, e, lon_0, t_c, m_c, pm, kernel::K) where {T,K}
@@ -111,7 +110,7 @@ PolarStereographicToLonLat(; kwargs...) = PolarStereographicToLonLat{Float64}(; 
     latr = lat * p.d2r * p.pm
     s = Math.sin(K, latr)
     t = Math.tan(K, T(pi / 4) - latr / 2) /
-        Math.pow(K, (1 - p.e * s) / (1 + p.e * s), p.ehalf)
+        Math.conformal_ratio(K, p.e, p.e * s)
     rho = p.a * p.m_c * t / p.t_c            # true scale at lat_ts
     dl = lon * p.d2r * p.pm - p.lon_0
     sdl, cdl = Math.sincos(K, dl)
@@ -151,7 +150,7 @@ fuses_direction(::LonLatToPolarStereographic) = true
     R = sqrt(dir.d * dir.d + zp * zp)
     s = zp / R
     t = (dir.d / (R + zp)) /
-        Math.pow(K, (1 - p.e * s) / (1 + p.e * s), p.ehalf)
+        Math.conformal_ratio(K, p.e, p.e * s)
     rho = p.a * p.m_c * t / p.t_c
     # sin and cos of (lon * pm - lon_0), by angle subtraction on the direction's
     # own sine and cosine against the central meridian's precomputed pair.

--- a/src/projections/tranmerc.jl
+++ b/src/projections/tranmerc.jl
@@ -230,19 +230,20 @@ end
 # ---------------------------------------------------------------------------
 
 """
-    _taupf(K, tau, tau1, e, ehalf)
+    _taupf(K, tau, tau1, e)
 
 `taup = cosh(σ)·tau − sinh(σ)·hypot(1, tau)` with `σ = e·atanh(e·sinφ)`: the
 tangent of the conformal latitude given the tangent of the geodetic one.
 
 Written through `w = exp(σ) = ((1+u)/(1−u))^(e/2)` rather than as
-`sinh(e·atanh(u))`. SLEEF has no fast `atanh` or `sinh`, and those two together
-cost about three times the one `pow` this needs -- which matters because the
-inverse evaluates this five times per point inside a Newton solve.
+`sinh(e·atanh(u))`, which SLEEF has no fast form of. `w` is
+[`Math.conformal_ratio`](@ref) at `-u`, since that computes the reciprocal
+ratio; getting it as a short series rather than a `pow` matters most here,
+because the inverse evaluates this five times per point inside a Newton solve.
 """
-@inline function _taupf(K, tau, tau1, e, ehalf)
+@inline function _taupf(K, tau, tau1, e)
     u = e * tau / tau1
-    w = Math.pow(K, (one(u) + u) / (one(u) - u), ehalf)
+    w = Math.conformal_ratio(K, e, -u)
     wi = inv(w)
     ((w + wi) * tau - (w - wi) * tau1) / 2
 end
@@ -405,7 +406,7 @@ end
 
     tau = slat / max(t.fmin, clat)
     tau1 = sqrt(tau * tau + one(tau))
-    taup = _taupf(K, tau, tau1, t.e, t.e / 2)
+    taup = _taupf(K, tau, tau1, t.e)
     htc = sqrt(taup * taup + clam * clam)
 
     atpole = at90
@@ -485,9 +486,9 @@ end
 end
 
 # one Newton step recovering tau from taup (Karney eq. 20)
-@inline function _tau_step(K, tau, taup_target, e, ehalf, e2m)
+@inline function _tau_step(K, tau, taup_target, e, e2m)
     tau1 = sqrt(tau * tau + one(tau))
-    taupa = _taupf(K, tau, tau1, e, ehalf)
+    taupa = _taupf(K, tau, tau1, e)
     tau + (taup_target - taupa) * (one(tau) + e2m * tau * tau) /
           (e2m * tau1 * sqrt(taupa * taupa + one(taupa)))
 end
@@ -547,11 +548,10 @@ end
     # last ulp is reached after two; Karney's own solver stops there too. The
     # old array kernel ran five unconditionally because a `@turbo` loop cannot
     # break out early.
-    eh = t.e / 2
     tau = sr / t.e2m
-    tau = _tau_step(K, tau, sr, t.e, eh, t.e2m)
-    tau = _tau_step(K, tau, sr, t.e, eh, t.e2m)
-    tau = _tau_step(K, tau, sr, t.e, eh, t.e2m)
+    tau = _tau_step(K, tau, sr, t.e, t.e2m)
+    tau = _tau_step(K, tau, sr, t.e, t.e2m)
+    tau = _tau_step(K, tau, sr, t.e, t.e2m)
 
     lat = Math.atan(K, tau) / d2r
 

--- a/test/transformations.jl
+++ b/test/transformations.jl
@@ -357,6 +357,27 @@ end
         @test FastGeoProjections.vectorizes(FastKernel())
         @test FastGeoProjections.vectorizes(SLEEFKernel())
         @test !FastGeoProjections.vectorizes(BaseKernel())
+
+        @testset "conformal_ratio is a pow to one ulp" begin
+            # Its contract is `e < 0.09` and `|u| <= e`; inside that the series
+            # must be indistinguishable from the `pow` it replaces, since the
+            # projections' agreement with PROJ rests on it.
+            for K in (FastKernel(), SLEEFKernel(), BaseKernel())
+                worst = 0.0
+                for e in (0.0, 0.0033528, 0.081819190842621278, 0.0818191910428, 0.089)
+                    for u in range(-e, e; length = 401)
+                        want = ((1 - u) / (1 + u))^(e / 2)
+                        got = Math.conformal_ratio(K, e, u)
+                        worst = max(worst, abs(got - want) / abs(want))
+                    end
+                end
+                @test worst <= 2eps(Float64)
+            end
+            # e = 0 is the sphere: the factor is exactly 1 and must not drift.
+            @test Math.conformal_ratio(FastKernel(), 0.0, 0.0) === 1.0
+            # Float32 carries through without widening.
+            @test Math.conformal_ratio(FastKernel(), 0.0818f0, 0.05f0) isa Float32
+        end
     end
 end
 


### PR DESCRIPTION
`Math.pow` does not vectorize. `code_llvm` on a loop calling it contains **no `<2 x double>` at all**, where the same loop over the series below contains 25 — and it costs about five times any other transcendental.

The cause is composition rather than the function. `SLEEFPirates.pow_fast` is one line, `exp2(y * log2_fast(x))`, and both halves vectorize on their own:

| | ns/point |
|---|---|
| `exp2` alone in a loop | 1.83 |
| `log2_fast` alone in a loop | 1.46 |
| the two in separate passes over an array | 3.34 |
| the two fused into one loop | 6.55 |
| `pow_fast` (identical code) | 10.28 |

LLVM will not vectorize a body holding both inlined. No general implementation can avoid this: handling negative bases, integer exponents and the infinities is exactly what makes a correct `pow` too large to vectorize, so there is nothing to fix upstream.

### The series

`Math.conformal_ratio` computes the same quantity by not being general. Both polar stereographic and transverse Mercator want `((1 − u)/(1 + u))^(e/2)` at `u = e·sin(lat)`, which is `exp(−e·atanh(u))`. Ellipsoids in use have `e < 0.09`, so `|u| ≤ 0.082` bounds atanh's odd series and `|e·atanh(u)| < 7e-3` bounds exp's — six terms each reach one ulp, in twelve fused multiply-adds with no branch, no table and no exponent manipulation.

Coefficients were derived analytically at 256-bit precision; the term counts are the minimum that reach `eps(Float64)` (six and six give 2.213e-16, five and six give 8.4e-15).

### Results

Out of place, 100k points:

| pipeline | 1 thread | 8 threads |
|---|---|---|
| 4326→3413 polar stereographic | 21.18 → **9.74** (−54%) | 4.1 → **2.68** |
| 4326→32619 UTM | 69.39 → **48.07** (−31%) | 12.6 → **8.70** |
| 4978→3413 fused geocentric | 59.81 → **33.96** (−43%) | — |

The 8-thread polar stereographic figure is parity with the `@turbo` array kernel this package replaced (2.60 ns/point), closing the regression measured in #29.

### Correctness

Agreement with PROJ is unchanged — 3.7e-9 m for UTM, 3.9e-7 m for polar stereographic, and the inverse directions likewise. A new test asserts the series is within two ulps of the `pow` it replaces across the whole contract range (`e` from 0 to 0.089, `|u| ≤ e`) for all three math kernels, plus the sphere case `e = 0` returning exactly `1.0` and `Float32` not widening. The `e < 0.09` bound is documented as the contract.

Full suite green at 1 and 8 threads.

### Also

- `ehalf` is gone from `LonLatToPolarStereographic` and from `_taupf`/`_tau_step`, which no longer need a halved eccentricity.
- `CLAUDE.md` added, describing the current architecture. It records two things measured while investigating this: `pick_vector_width(Float64)` is 2 on aarch64 (a `VecUnroll{U,2}` is an unroll factor, not a lane count), and the array-path noise band is about ±8%, so a single 5% measurement has measured nothing.
- `benchmark/optimize_bench.jl` added — the harness these numbers come from. The committed `benchmark/` project pulls GLMakie and will not precompile headless, so this is meant to be run from a scratch environment.

Co-authored-by: Claude <noreply@anthropic.com>
