### PR TITLE
Make the juliac example actually trim

### DIFF
--- a/examples/juliac/LocalPreferences.toml
+++ b/examples/juliac/LocalPreferences.toml
@@ -1,0 +1,2 @@
+[HostCPUFeatures]
+freeze_cpu_target = true

--- a/examples/juliac/LocalPreferences.toml
+++ b/examples/juliac/LocalPreferences.toml
@@ -1,2 +1,0 @@
-[HostCPUFeatures]
-freeze_cpu_target = true

--- a/examples/juliac/Project.toml
+++ b/examples/juliac/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 FastGeoProjections = "981663e8-0c94-46dd-b2cf-efc8480900ec"
+HostCPUFeatures = "3e5b6fbb-0976-4d2c-9146-d79de83f2fb0"
 
 [sources]
 FastGeoProjections = {path = "../.."}

--- a/examples/juliac/Project.toml
+++ b/examples/juliac/Project.toml
@@ -1,9 +1,9 @@
 [deps]
 FastGeoProjections = "981663e8-0c94-46dd-b2cf-efc8480900ec"
-HostCPUFeatures = "3e5b6fbb-0976-4d2c-9146-d79de83f2fb0"
+JuliaC = "acedd4c2-ced6-4a15-accc-2607eb759ba2"
 
 [sources]
 FastGeoProjections = {path = "../.."}
 
 [compat]
-julia = "1.12"
+julia = "1.13"

--- a/examples/juliac/README.md
+++ b/examples/juliac/README.md
@@ -88,17 +88,20 @@ than from a vector's contents, and the answer is a `Val{T}` rather than a
 is a package-side concern rather than something this app does, but it is what
 keeps the whole array path reachable ahead of time: returning the float type as
 an ordinary value leaves `_transform_interleaved!` unresolved for every
-operator, which is 40 verifier errors rather than the 2 below.
+operator, which is 40 verifier errors and no trimmed binary.
 
 ## What does not survive trimming
 
-**Two verifier errors, always.** Both come from `HostCPUFeatures.__init__`,
-which `dlopen`s LLVM at load time to read the host's CPU feature string. It is
-a transitive dependency of VectorizationBase, three levels below anything this
-program calls, and there is no way to opt out of a module's `__init__`. The
-code works at run time — `libjulia` is linked, so the `dlopen` succeeds — which
-is why the default build is `--trim=unsafe-warn`. A build with `--trim=safe`
-reports the same two and stops.
+The build defaults to `--trim=safe`, which fails on any unresolved call. Any
+verifier error means the program did not trim, whatever `--trim=unsafe-warn`
+may go on to link.
+
+**A preference is needed to get there.** `HostCPUFeatures.__init__` reaches a
+`dlopen` of LLVM to read the host's CPU feature string, which the verifier
+cannot resolve; nothing here uses that package, it arrives through
+VectorizationBase. `LocalPreferences.toml` sets its `freeze_cpu_target`, which
+makes the path statically dead — `build.jl` explains why in full, including
+why HostCPUFeatures has to be a direct dependency for the setting to apply.
 
 **Threads.** `Threads.@threads` does not work in a trimmed binary: the task
 bodies it creates are reached only through the scheduler, so they are not in
@@ -114,9 +117,8 @@ something to anchor on. Keep the struct monomorphic (dispatch the projection
 *inside* the task, not by parameterizing the job) so one declaration covers
 every CRS pair.
 
-**Relocatability.** The binary links only `libjulia`, but `HostCPUFeatures` and
-`libproj_jll` `dlopen` their libraries from absolute paths in the Julia depot
-at startup. It runs anywhere that depot is; it is not a copy-anywhere artifact.
+**Relocatability.** The binary links only `libjulia`, but `libproj_jll`
+`dlopen`s its library from an absolute path in the Julia depot at startup. It runs anywhere that depot is; it is not a copy-anywhere artifact.
 Shipping one would mean bundling those with `--relative-rpath`.
 
 ## Numbers

--- a/examples/juliac/README.md
+++ b/examples/juliac/README.md
@@ -7,7 +7,7 @@ an executable with no Julia startup and no compilation at run time.
 ```console
 $ ./fastgeoproj --input sample.csv --from 4326 --to 32619 --always-xy
 500000.0,4.982950400226553e6
-380244.57633207337,4.900734380124455e6
+380244.57633207337,4.900734380124453e6
 557548.832534876,5.149876586070551e6
 426642.267622362,4.761207746467653e6
 319952.79600128037,4.735400315222241e6
@@ -25,10 +25,10 @@ Needs **Julia 1.12 or later** and a C compiler on `PATH` for the final link.
 $ julia --project=examples/juliac examples/juliac/build.jl
 ```
 
-That produces `examples/juliac/fastgeoproj` (about 17 MiB) in about half a
-minute. `build.jl --trim=safe` makes the build fail on any unresolved call
-instead of warning; see *What does not survive trimming* below for the two that
-are expected.
+That produces `examples/juliac/fastgeoproj` (about 15 MiB) in about half a
+minute. The build fails on any unresolved call; `build.jl --trim=unsafe-warn`
+downgrades those to warnings and links anyway, which is only useful for seeing
+the whole list at once.
 
 ## Use
 
@@ -43,10 +43,15 @@ Usage: fastgeoproj --input FILE --from EPSG --to EPSG [--output FILE]
                       than in the authority order (lat, lon)
 ```
 
-Supported codes are the ones FastGeoProjections implements natively — 4326,
-3031, 3413, and the 120 WGS 84 UTM zones (32601–32660, 32701–32760). Any pair
-of them works, composed through EPSG:4326: `--from 32619 --to 32620` is one
-pass over the data, not two.
+Supported codes are 4326, 3031, 3413, and the 120 WGS 84 UTM zones
+(32601–32660, 32701–32760). Any pair of them works, composed through EPSG:4326:
+`--from 32619 --to 32620` is one pass over the data, not two. Anything else is
+an error naming the code.
+
+That is the two-dimensional part of what the package implements natively. It
+also has EPSG:4978 (geocentric) and 4979 (geographic 3D), which this tool does
+not offer because its CSV is exactly two columns; a third would be a real
+addition rather than another branch in `with_source`/`with_target`.
 
 Without `--always-xy`, EPSG:4326 columns are `(lat, lon)`, which is the axis
 order the authority defines and what `cs2cs` expects. Projected CRSs are always
@@ -125,28 +130,30 @@ Shipping one would mean bundling those with `--relative-rpath`.
 
 Measured on an M4 Pro, 1,000,000 random points, Julia 1.12.7.
 
-**Agreement with Proj**, comparing the binary's output against `Proj.jl` over
-grids covering each projection's domain:
+**Agreement with Proj**, over grids covering each projection's domain — the
+polar caps at 1° of latitude by 5° of longitude, each UTM zone at ±3° of its
+central meridian by 3° of latitude:
 
 | conversion | max abs. difference |
 | --- | --- |
-| 4326 → 3413 | 2.8e-9 m |
-| 4326 → 3031 | 1.9e-9 m |
-| 4326 → all 120 UTM zones | 5.2e-9 m |
+| 4326 → 3413 | 2.2e-9 m |
+| 4326 → 3031 | 2.1e-9 m |
+| 4326 → all 120 UTM zones | 5.5e-9 m |
 | all 120 UTM zones → 4326 | 5.7e-14 ° |
-| 3413 → 4326 | 7.6e-12 ° |
+| 3413 → 4326 | 1.3e-12 ° |
+| 3031 → 4326 | 1.4e-12 ° |
 
 **Speed**, 4326 → 3413, one thread, output to `/dev/null`:
 
 | | wall time |
 | --- | --- |
 | `fastgeoproj` | 0.18 s |
-| `cs2cs` (PROJ 9.8.1) | 1.19 s |
+| `cs2cs` (PROJ 9.8.1) | 1.22 s |
 
-Same values to the digits `cs2cs -d 10` prints. It is not a perfectly matched
-comparison — `cs2cs` also emits a third `z` column, so it writes 27% more text
-(52.6 MB against 41.4 MB) — but the gap is not close enough for that to
-explain it.
+The two agree to 3.6e-9 m over the million points. It is not a perfectly
+matched comparison — `cs2cs` also emits a third `z` column, so it writes 28%
+more text (50.6 MB against 39.6 MB) — but the gap is not close enough for that
+to explain it.
 
 Startup, on a one-line file, is 30 ms. The same script run through `julia`
 instead of compiled takes 14.4 s for the same work, essentially all of it
@@ -158,11 +165,13 @@ package loading and JIT.
 | --- | --- |
 | read the file | 8 |
 | parse text → `Float64` | 76 |
-| **transform** | **14** |
+| **transform** | **7** |
 | format `Float64` → text and write | 44 |
 
-The projection is 9% of the run. Turning text into floats and back is the
-expensive half of a CSV tool, which is why the writer goes straight to a byte
-buffer with `Ryu.writeshortest` (about 4× an `IOBuffer` a field at a time, same
-shortest-round-trip digits) — and why threading the transform, if it were
-available, would buy under 10% end to end.
+The projection is 5% of the run, and was 9% before the polar stereographic
+forward traded its `pow` for a series (14 ms to 7 ms on the same points).
+Turning text into floats and back is the expensive half of a CSV tool, which is
+why the writer goes straight to a byte buffer with `Ryu.writeshortest` (about
+4× an `IOBuffer` a field at a time, same shortest-round-trip digits) — and why
+threading the transform, if it were available, would buy under 10% end to
+end.

--- a/examples/juliac/README.md
+++ b/examples/juliac/README.md
@@ -4,6 +4,14 @@ A worked example of compiling FastGeoProjections ahead of time with
 [`juliac`](https://github.com/JuliaLang/julia/tree/master/contrib/juliac) into
 an executable with no Julia startup and no compilation at run time.
 
+> **Julia 1.13 or later.** `juliac` now ships as the [JuliaC
+> package](https://github.com/JuliaLang/JuliaC.jl) rather than as part of the
+> distribution, so it is a dependency of this project. More to the point, 1.13
+> is the first version that keeps task bodies in a trimmed image, which makes it
+> the first version where the threaded transform survives. On 1.12 the build
+> succeeds, reports zero errors, and the binary dies at run time — see [what
+> trimming does and does not reach](#what-trimming-does-and-does-not-reach).
+
 ```console
 $ ./fastgeoproj --input sample.csv --from 4326 --to 32619 --always-xy
 500000.0,4.982950400226553e6
@@ -19,7 +27,7 @@ all accepted. Anything else is an error naming the line.
 
 ## Build
 
-Needs **Julia 1.12 or later** and a C compiler on `PATH` for the final link.
+Needs **Julia 1.13 or later** and a C compiler on `PATH` for the final link.
 
 ```console
 $ julia --project=examples/juliac examples/juliac/build.jl
@@ -95,32 +103,41 @@ keeps the whole array path reachable ahead of time: returning the float type as
 an ordinary value leaves `_transform_interleaved!` unresolved for every
 operator, which is 40 verifier errors and no trimmed binary.
 
-## What does not survive trimming
+## What trimming does and does not reach
 
 The build defaults to `--trim=safe`, which fails on any unresolved call. Any
 verifier error means the program did not trim, whatever `--trim=unsafe-warn`
 may go on to link.
 
-**A preference is needed to get there.** `HostCPUFeatures.__init__` reaches a
-`dlopen` of LLVM to read the host's CPU feature string, which the verifier
-cannot resolve; nothing here uses that package, it arrives through
-VectorizationBase. `LocalPreferences.toml` sets its `freeze_cpu_target`, which
-makes the path statically dead — `build.jl` explains why in full, including
-why HostCPUFeatures has to be a direct dependency for the setting to apply.
+**Threads work here, and did not on 1.12.** A task's function is stored in the
+task object by `jl_new_task` and invoked later by the scheduler, from C. No
+Julia call site refers to it — the optimized IR of a function that spawns work
+contains `jl_new_task`, `enq_work` and `_wait`, and no edge to the body at all
+— so a reachability walk over the visible call graph never finds it. On 1.12
+the body was left out of the image and the loop died with a `MethodError` on
+the first chunk.
 
-**Threads.** `Threads.@threads` does not work in a trimmed binary: the task
-bodies it creates are reached only through the scheduler, so they are not in
-the image and the loop dies with a `MethodError` on the first chunk. This is a
-`juliac` limitation, not a FastGeoProjections one — a six-line program that
-fills an array in parallel fails the same way. So `reproject!` passes
-`threaded = false`.
+That is the one failure trimming will not warn you about. There is no
+unresolved *call site*, because there is no call site, so `--trim=safe` reports
+zero errors and links a binary that cannot run its own threaded loop. The
+verifier sees Julia; it cannot see through C.
 
-That costs less than it sounds like: see below. If you do want it, the pattern
-that works is an explicit `Task` over a *named* callable struct plus
-`Base.Experimental.entrypoint(Tuple{YourJobType})`, which gives the trimmer
-something to anchor on. Keep the struct monomorphic (dispatch the projection
-*inside* the task, not by parameterizing the job) so one declaration covers
-every CRS pair.
+1.13 roots lowering-generated closures used as task bodies. That covers
+`Threads.@threads`, `Threads.@spawn`, `StableTasks.@spawn` and a plain
+`Task(() -> ...)` alike — they all hand `Task` a closure, and which macro built
+it makes no difference. The exception is a *named* callable struct passed
+straight to `Task`, which is rooted only if you declare
+`Base.Experimental.entrypoint(Tuple{YourJobType})` yourself. That declaration is
+also the only thing that worked on 1.12, where nothing was rooted automatically;
+keep such a struct monomorphic (dispatch the projection *inside* the task rather
+than parameterizing the job) so one declaration covers every CRS pair.
+
+**One workaround this example no longer needs.** On 1.12 the build could not
+resolve a `dlopen` of libLLVM inside `HostCPUFeatures.__init__`, reached through
+VectorizationBase, and the fix was a `freeze_cpu_target` preference plus a
+direct dependency to make that preference apply. On 1.13 the build is clean
+without any of it. `build.jl` records what it was, since the shape of the
+problem outlives this instance of it.
 
 **Relocatability.** The binary links only `libjulia`, but `libproj_jll`
 `dlopen`s its library from an absolute path in the Julia depot at startup. It runs anywhere that depot is; it is not a copy-anywhere artifact.
@@ -128,7 +145,7 @@ Shipping one would mean bundling those with `--relative-rpath`.
 
 ## Numbers
 
-Measured on an M4 Pro, 1,000,000 random points, Julia 1.12.7.
+Measured on an M4 Pro, 1,000,000 random points, Julia 1.13.0-rc4.
 
 **Agreement with Proj**, over grids covering each projection's domain — the
 polar caps at 1° of latitude by 5° of longitude, each UTM zone at ±3° of its
@@ -159,19 +176,35 @@ Startup, on a one-line file, is 30 ms. The same script run through `julia`
 instead of compiled takes 14.4 s for the same work, essentially all of it
 package loading and JIT.
 
+**Threads.** A trimmed binary reads `JULIA_NUM_THREADS` as usual and defaults to
+one, so the threading is there to be asked for. End to end it is close to
+invisible — 0.20 s on one thread against 0.17 s on eight, most of that spread
+being run-to-run noise — because only the transform is threaded and the
+transform is 5% of the run. In isolation it scales properly:
+
+| threads | `transform!`, 1e6 points | |
+| --- | --- | --- |
+| 1 | 8.0 ms | |
+| 2 | 4.9 ms | 1.7× |
+| 4 | 2.3 ms | 3.5× |
+| 8 | 1.6 ms | 5.1× |
+
+Output is byte-identical at every thread count, and identical to what the 1.12
+single-threaded build produced.
+
 **Where the time goes**, in process, 1M points:
 
 | phase | ms |
 | --- | --- |
 | read the file | 8 |
 | parse text → `Float64` | 76 |
-| **transform** | **7** |
+| **transform** | **8** |
 | format `Float64` → text and write | 44 |
 
 The projection is 5% of the run, and was 9% before the polar stereographic
-forward traded its `pow` for a series (14 ms to 7 ms on the same points).
-Turning text into floats and back is the expensive half of a CSV tool, which is
-why the writer goes straight to a byte buffer with `Ryu.writeshortest` (about
-4× an `IOBuffer` a field at a time, same shortest-round-trip digits) — and why
-threading the transform, if it were available, would buy under 10% end to
-end.
+forward traded its `pow` for a series — 14.2 ms against 7.4 ms measured back to
+back on 1.12, where the change landed. Turning text into floats and back is the
+expensive half of a CSV tool, which is why the writer goes straight to a byte
+buffer with `Ryu.writeshortest` (about 4× an `IOBuffer` a field at a time, same
+shortest-round-trip digits) — and why threading the transform, now that it
+survives trimming, still buys under 5% end to end.

--- a/examples/juliac/build.jl
+++ b/examples/juliac/build.jl
@@ -5,11 +5,59 @@
 #     julia --project=examples/juliac examples/juliac/build.jl
 #
 # Options:
-#     --trim=safe          fail the build on any unresolved call (see README)
-#     --trim=unsafe-warn   report them and build anyway (the default)
+#     --trim=safe          fail the build on any unresolved call (the default)
+#     --trim=unsafe-warn   report them and build anyway
 #     --output-exe PATH    where to put the binary
 #
 # Needs Julia 1.12 or later, and a C compiler on PATH for the final link.
+#
+# ---------------------------------------------------------------------------
+# Why LocalPreferences.toml sets HostCPUFeatures.freeze_cpu_target
+#
+# Without it this program does not trim. `--trim=safe` fails with two
+# unresolved calls:
+#
+#     [1] feature_string()   HostCPUFeatures/src/cpu_info.jl:3   <- dlopen(libLLVM)
+#     [2] reset_features!()  HostCPUFeatures/src/cpu_info.jl:48
+#     [3] redefine()         HostCPUFeatures/src/HostCPUFeatures.jl:62
+#     [4] __init__()         HostCPUFeatures/src/HostCPUFeatures.jl:95
+#
+# `HostCPUFeatures.__init__` calls `redefine()` when the CPU name it saw at
+# precompile time differs from the one it sees at run time, and that reaches a
+# `dlopen` of libLLVM to read `LLVMGetHostCPUFeatures`. The verifier cannot
+# prove the branch is dead, so it follows it. `--trim=unsafe-warn` reports the
+# two and links anyway, which is easy to mistake for success: any verifier
+# error means the program did not trim.
+#
+# Nothing here uses HostCPUFeatures. It arrives through VectorizationBase --
+# the only package in the manifest that depends on it -- which FastGeoProjections
+# uses for `vload`/`vstore!`/`stridedpointer`/`MM`/`mask`, and which
+# SLEEFPirates depends on in turn. Its one job in that chain is to work out the
+# vector register width at load time.
+#
+# `__init__` returns early when `freeze_cpu_target` is set, and that is a
+# `const` read from a Preference, so setting it makes the whole path
+# statically dead:
+#
+#     [HostCPUFeatures]
+#     freeze_cpu_target = true
+#
+# For an ahead-of-time build this is the honest setting rather than a dodge.
+# juliac already compiles with `-C native`, so the vector width is baked into
+# the emitted lane loops; a binary that discovered a wider register at startup
+# could not use it. HostCPUFeatures is a direct dependency of this project for
+# no other reason: Preferences are only applied to direct dependencies, and as
+# a transitive one the setting is read and ignored.
+#
+# Measured on aarch64: `pick_vector_width` is unchanged at 2 x Float64 /
+# 4 x Float32, output is byte-identical, and 1e6 points still take 0.17 s. On
+# x86 the setting freezes an *under-approximation* of the CPU features, so
+# check `VectorizationBase.pick_vector_width` there before trusting it.
+#
+# Removing the dependency outright would mean replacing VectorizationBase's
+# lane primitives and SLEEFPirates' kernels both -- the whole vectorization
+# layer -- which is a much larger question than this example.
+# ---------------------------------------------------------------------------
 
 using Pkg
 Pkg.instantiate()
@@ -23,7 +71,7 @@ isfile(JULIAC) ||
           Ahead-of-time compilation needs Julia 1.12 or later; this is $VERSION.
           """)
 
-trim = "unsafe-warn"
+trim = "safe"
 out = joinpath(HERE, "fastgeoproj")
 i = 1
 while i <= length(ARGS)

--- a/examples/juliac/build.jl
+++ b/examples/juliac/build.jl
@@ -49,10 +49,11 @@
 # no other reason: Preferences are only applied to direct dependencies, and as
 # a transitive one the setting is read and ignored.
 #
-# Measured on aarch64: `pick_vector_width` is unchanged at 2 x Float64 /
-# 4 x Float32, output is byte-identical, and 1e6 points still take 0.17 s. On
-# x86 the setting freezes an *under-approximation* of the CPU features, so
-# check `VectorizationBase.pick_vector_width` there before trusting it.
+# Measured on aarch64, building both ways and diffing: `pick_vector_width` is
+# unchanged at 2 x Float64 / 4 x Float32, output is byte-identical, and 1e6
+# points take 0.18 s either way. On x86 the setting freezes an
+# *under-approximation* of the CPU features, so check
+# `VectorizationBase.pick_vector_width` there before trusting it.
 #
 # Removing the dependency outright would mean replacing VectorizationBase's
 # lane primitives and SLEEFPirates' kernels both -- the whole vectorization

--- a/examples/juliac/build.jl
+++ b/examples/juliac/build.jl
@@ -7,73 +7,58 @@
 # Options:
 #     --trim=safe          fail the build on any unresolved call (the default)
 #     --trim=unsafe-warn   report them and build anyway
-#     --output-exe PATH    where to put the binary
+#     --output-exe NAME    executable name, written next to this script
 #
-# Needs Julia 1.12 or later, and a C compiler on PATH for the final link.
+# Needs Julia 1.13 or later, and a C compiler on PATH for the final link.
 #
 # ---------------------------------------------------------------------------
-# Why LocalPreferences.toml sets HostCPUFeatures.freeze_cpu_target
+# Why 1.13 and not 1.12
 #
-# Without it this program does not trim. `--trim=safe` fails with two
-# unresolved calls:
+# `juliac` moved out of the Julia distribution and into the JuliaC package, so
+# it is a dependency of this project rather than a script under `Sys.BINDIR`.
+# That is the mechanical difference. The substantive one is that 1.13 compiles
+# task bodies that 1.12 discarded.
 #
-#     [1] feature_string()   HostCPUFeatures/src/cpu_info.jl:3   <- dlopen(libLLVM)
-#     [2] reset_features!()  HostCPUFeatures/src/cpu_info.jl:48
-#     [3] redefine()         HostCPUFeatures/src/HostCPUFeatures.jl:62
-#     [4] __init__()         HostCPUFeatures/src/HostCPUFeatures.jl:95
+# A task's function is stored in the task object by `jl_new_task` and invoked
+# later by the scheduler, in C. There is no Julia call site to it, so a
+# reachability walk over the visible call graph never reaches it. On 1.12 the
+# body is left out of the image and the program dies at run time with a
+# `MethodError` -- and because there is no unresolved *call site*, `--trim=safe`
+# reports zero errors and links happily. It is the one failure mode trimming
+# does not catch.
 #
-# `HostCPUFeatures.__init__` calls `redefine()` when the CPU name it saw at
-# precompile time differs from the one it sees at run time, and that reaches a
-# `dlopen` of libLLVM to read `LLVMGetHostCPUFeatures`. The verifier cannot
-# prove the branch is dead, so it follows it. `--trim=unsafe-warn` reports the
-# two and links anyway, which is easy to mistake for success: any verifier
-# error means the program did not trim.
+# 1.13 roots lowering-generated closures used as task bodies, which covers
+# `Threads.@threads`, `Threads.@spawn` and a hand-written `Task(() -> ...)`
+# alike. So `transform!(...; threaded = true)` works here, where on 1.12 it
+# needed `Base.Experimental.entrypoint` on a named callable struct -- the only
+# shape 1.13 does *not* root for you.
 #
-# Nothing here uses HostCPUFeatures. It arrives through VectorizationBase --
-# the only package in the manifest that depends on it -- which FastGeoProjections
-# uses for `vload`/`vstore!`/`stridedpointer`/`MM`/`mask`, and which
-# SLEEFPirates depends on in turn. Its one job in that chain is to work out the
-# vector register width at load time.
-#
-# `__init__` returns early when `freeze_cpu_target` is set, and that is a
-# `const` read from a Preference, so setting it makes the whole path
-# statically dead:
-#
-#     [HostCPUFeatures]
-#     freeze_cpu_target = true
-#
-# For an ahead-of-time build this is the honest setting rather than a dodge.
-# juliac already compiles with `-C native`, so the vector width is baked into
-# the emitted lane loops; a binary that discovered a wider register at startup
-# could not use it. HostCPUFeatures is a direct dependency of this project for
-# no other reason: Preferences are only applied to direct dependencies, and as
-# a transitive one the setting is read and ignored.
-#
-# Measured on aarch64, building both ways and diffing: `pick_vector_width` is
-# unchanged at 2 x Float64 / 4 x Float32, output is byte-identical, and 1e6
-# points take 0.18 s either way. On x86 the setting freezes an
-# *under-approximation* of the CPU features, so check
-# `VectorizationBase.pick_vector_width` there before trusting it.
-#
-# Removing the dependency outright would mean replacing VectorizationBase's
-# lane primitives and SLEEFPirates' kernels both -- the whole vectorization
-# layer -- which is a much larger question than this example.
+# Moving to 1.13 also retired a workaround this example used to need.
+# `HostCPUFeatures.__init__` reaches a `dlopen` of libLLVM to read the host CPU
+# feature string, which 1.12's verifier could not resolve; the fix was to set
+# that package's `freeze_cpu_target` preference, which made the branch
+# statically dead, and to depend on it directly since Preferences apply only to
+# direct dependencies. On 1.13 the build is clean without any of it, verified
+# from a cleared cache with the preference reading `false`.
 # ---------------------------------------------------------------------------
+
+# Checked before instantiating: on an older Julia the resolve fails first, with
+# a precompile error that says nothing about the actual problem.
+VERSION >= v"1.13.0-" ||
+    error("""
+          Ahead-of-time compilation here needs Julia 1.13 or later; this is $VERSION.
+          On 1.12 the build runs but the threaded transform is left out of the
+          image, and `--trim=safe` does not report it. See the comment at the
+          top of this file.
+          """)
 
 using Pkg
 Pkg.instantiate()
 
 const HERE = @__DIR__
-const JULIAC = joinpath(Sys.BINDIR, Base.DATAROOTDIR, "julia", "juliac", "juliac.jl")
-
-isfile(JULIAC) ||
-    error("""
-          juliac.jl is not at $JULIAC.
-          Ahead-of-time compilation needs Julia 1.12 or later; this is $VERSION.
-          """)
 
 trim = "safe"
-out = joinpath(HERE, "fastgeoproj")
+out = "fastgeoproj"
 i = 1
 while i <= length(ARGS)
     a = ARGS[i]
@@ -89,10 +74,12 @@ while i <= length(ARGS)
     global i = i + 1
 end
 
-cmd = `$(Base.julia_cmd()) --startup-file=no --history-file=no --project=$HERE
-       $JULIAC --output-exe $out --experimental --trim=$trim
-       $(joinpath(HERE, "fastgeoproj.jl"))`
+# `--output-exe` takes a bare name and writes it to the working directory, so
+# the build runs in this one.
+cmd = Cmd(`$(Base.julia_cmd()) --startup-file=no --history-file=no --project=$HERE
+           -m JuliaC --project $HERE --output-exe $out
+           --experimental --trim=$trim fastgeoproj.jl`; dir = HERE)
 
 @info "building" out trim
 run(cmd)
-@info "built" out size = Base.format_bytes(filesize(out))
+@info "built" out size = Base.format_bytes(filesize(joinpath(HERE, out)))

--- a/examples/juliac/fastgeoproj.jl
+++ b/examples/juliac/fastgeoproj.jl
@@ -262,13 +262,18 @@ end
     end
 end
 
-# `threaded = false`: `Threads.@threads` does not survive `--trim` (see
-# README.md). The projection is a small part of the run time here anyway --
-# turning text into floats and back is the expensive half of a CSV tool.
+# `threaded = true` works because 1.13 keeps task bodies in a trimmed image; on
+# 1.12 this call compiled and then died at run time (see README.md). Threads
+# come from `JULIA_NUM_THREADS`, which a trimmed binary reads as usual, so this
+# is one thread unless the caller asks for more.
+#
+# It buys little here: the projection is 5% of the run, and turning text into
+# floats and back is the expensive half of a CSV tool. The transform itself
+# scales about 5x on eight threads.
 function reproject!(pts::Vector{Point}, o::Options)
     with_source(o.from, o.always_xy) do to_lonlat
         with_target(o.to, o.always_xy) do from_lonlat
-            transform!(from_lonlat ∘ to_lonlat, pts; threaded = false)
+            transform!(from_lonlat ∘ to_lonlat, pts; threaded = true)
             nothing
         end
     end


### PR DESCRIPTION
The juliac example compiles ahead of time on Julia 1.13 with `--trim=safe`, zero verifier errors, and the transform threaded.

### Task bodies and trimming

A task's function is stored by `jl_new_task` and invoked by the scheduler from C. The optimized IR of a spawning function holds `jl_new_task`, `enq_work` and `_wait` and no edge to the body, so `--trim`'s reachability walk drops it.

The verifier flags unresolved *call sites*, and this is not one. So `--trim=safe` reports zero errors and links a binary that dies at run time with a `MethodError` — the one failure trimming stays silent about.

Julia 1.13 roots lowering-generated closures used as task bodies. Built and ran each variant on both versions:

| body handed to `Task` | 1.12 | 1.13-rc4 |
| --- | --- | --- |
| `Threads.@threads` | ❌ | ✅ |
| `Threads.@spawn j()` | — | ✅ |
| `StableTasks.@spawn`, `wait` or `fetch` | ❌ | ✅ |
| `Task(() -> ...)`, no macro | ❌ | ✅ |
| `Task(NamedStruct(...))` | ❌ | ❌ |
| `Task(NamedStruct(...))` + `entrypoint` | ✅ | ✅ |

The closure decides it — not the macro, not the name. A named callable struct is the one shape 1.13 leaves alone, so it still needs `Base.Experimental.entrypoint`. That makes "give the job a nameable type so an entrypoint can be declared" a trade worth skipping on 1.13: it buys 1.12 support by giving up the automatic rooting.

### What this changes

- `reproject!` passes `threaded = true`. A trimmed binary reads `JULIA_NUM_THREADS` and defaults to one.
- The example targets 1.13 and takes `JuliaC` as a dependency, since juliac ships as a package now. `build.jl` runs `-m JuliaC` and checks `VERSION` before `Pkg.instantiate()`, where an older Julia otherwise fails the resolve with an unrelated precompile error.
- 1.13 resolves the libLLVM `dlopen` in `HostCPUFeatures.__init__` on its own, so the `freeze_cpu_target` preference, its dependency and `LocalPreferences.toml` are gone. `build.jl` records what the workaround was.
- The README's numbers, accuracy grid and supported-code list match the current tree.

### Numbers

`transform!` over 1e6 points scales 8.0 → 4.9 → 2.3 → 1.6 ms across 1, 2, 4 and 8 threads. End to end the CSV tool goes 0.20 s to 0.17 s, because the transform is 5% of the run and parsing and formatting are the rest. Output is byte-identical at every thread count and to the 1.12 build. The binary is 15.1 MiB and starts in 30 ms.

### Checks

Suite green at `JULIA_NUM_THREADS=4` on 1.12.7 and 1.13.0-rc4, 4,567 tests each. Package sources are untouched. Clean `--trim=safe` build from a cleared Manifest, verified with the compile cache cleared and `freeze_cpu_target` reading `false`. Agrees with `cs2cs` to 3.6e-9 m over 1e6 points.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Claude-Session: https://claude.ai/code/session_01G1s918NdVoRwtZ3wMpCzwf
